### PR TITLE
Fixes #4323 #4322 - Fix wrong result classes of service_ensure_stopped which are based on service_check_running() and remove useless variable about init.d command

### DIFF
--- a/tree/30_generic_methods/service_ensure_stopped.cf
+++ b/tree/30_generic_methods/service_ensure_stopped.cf
@@ -37,16 +37,23 @@ bundle agent service_ensure_stopped(service_name)
       "check running"
         usebundle  => service_check_running("${service_name}");
 
+      # If service_check_running has detected a process, it will result in
+      # a success, so we have to stop the process
       "stop if running"
         usebundle  => service_stop("${service_name}"),
-        ifvarclass => "service_check_running_${canonified_service_name}_ok";
+        ifvarclass => "service_check_running_${canonified_service_name}_kept";
 
-      "class copy check"
-        usebundle => _classes_copy_invert_kept_repaired("service_check_running_${canonified_service_name}", "${class_prefix");
+      # If service_check_running has no detected any process, it will not result
+      # in a success so the result class of this promise should be the a success.
+      "create success class"
+        usebundle => _classes_success("${class_prefix"),
+        ifvarclass => "!service_check_running_${canonified_service_name}_kept";
  
-     "class copy if running"
+     # If service_check_running has detected a process, the process will be
+     # stopped and the result class should be the same as this promise.
+      "class copy if running"
         usebundle => _classes_copy("service_stop_${canonified_service_name}", "${class_prefix}"),
-        ifvarclass => "service_stop_${canonified_service_name}_ok";
+        ifvarclass => "service_check_running_${canonified_service_name}_kept";
 
       "report"
         usebundle => _logger("Ensure that service ${service_name} is stopped", "${class_prefix}");


### PR DESCRIPTION
Fixes #4323 #4322 - Fix wrong result classes of service_ensure_stopped which are based on service_check_running() and remove useless variable about init.d command

cf http://www.rudder-project.org/redmine/issues/4323

This PR was originaly from https://github.com/Normation/ncf/pull/26
