### PR TITLE
Fixes #4344 - Add prefix to classes created by classes_success and classes_failure and add acceptance tests

### DIFF
--- a/tests/acceptance/30_generic_methods/class_failure.cf
+++ b/tests/acceptance/30_generic_methods/class_failure.cf
@@ -1,0 +1,52 @@
+#######################################################
+#
+# Test if only failure classes are created
+#
+#######################################################
+
+bundle common acc_path
+{
+  vars:
+    "root" string => getenv("NCF_TESTS_ACCEPTANCE", 1024);
+}
+
+body common control
+{
+      inputs => { "${acc_path.root}/default.cf.sub", "${acc_path.root}/default_ncf.cf.sub", "@{ncf_inputs.default_files}" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+    "tmp"         string => getenv("TEMP", 1024);
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+    "ph1"         usebundle => _classes_failure("my_class");
+
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok_success"  expression => "!(promise_kept_my_class|my_class_kept|my_class_ok)";
+      "ok_repaired" expression => "!(promise_repaired_my_class|my_class_repaired)";
+      "ok_error"    expression => "(repair_failed_my_class.my_class_failed.my_class_not_ok.my_class_not_kept.my_class_not_repaired.my_class_reached).!(repair_denied_class_my_class|repair_timeout_my_class|my_class_timeout|my_class_denied)";
+      "ok"          and        => { "ok_success", "ok_repaired", "ok_error" };
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tests/acceptance/30_generic_methods/class_success.cf
+++ b/tests/acceptance/30_generic_methods/class_success.cf
@@ -1,0 +1,52 @@
+#######################################################
+#
+# Test if only success classes are created
+#
+#######################################################
+
+bundle common acc_path
+{
+  vars:
+    "root" string => getenv("NCF_TESTS_ACCEPTANCE", 1024);
+}
+
+body common control
+{
+      inputs => { "${acc_path.root}/default.cf.sub", "${acc_path.root}/default_ncf.cf.sub", "@{ncf_inputs.default_files}" };
+      bundlesequence  => { default("$(this.promise_filename)") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+    "tmp"         string => getenv("TEMP", 1024);
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+    "ph1"         usebundle => _classes_success("my_class");
+
+}
+
+#######################################################
+
+bundle agent check
+{
+  classes:
+      "ok_success"  and        => { "promise_kept_my_class", "my_class_kept", "my_class_not_repaired", "my_class_ok", "my_class_reached" };
+      "ok_repaired" expression => "!(promise_repaired_my_class|my_class_repaired)";
+      "ok_error"    expression => "!(repair_failed_my_class|repair_denied_class_my_class|repair_timeout_my_class|my_class_failed|my_class_not_ok|my_class_not_kept|my_class_denied|my_class_timeout)";
+      "ok"          and        => { "ok_success", "ok_repaired", "ok_error" };
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}

--- a/tree/30_generic_methods/_classes_failure.cf
+++ b/tree/30_generic_methods/_classes_failure.cf
@@ -28,9 +28,15 @@
 bundle agent _classes_failure(class_prefix)
 {
   vars:
+      "prefix" slist => { "repair_failed" };
       "suffix" slist => { "not_kept", "not_ok", "not_repaired", "failed", "reached" };
+
+      "${prefix}_local"
+        string     => "${prefix}_${class_prefix}",
+        classes    => always("${prefix}_${class_prefix}");
 
       "local_${suffix}"
         string     => "${class_prefix}_${suffix}",
         classes    => always("${class_prefix}_${suffix}");
+
 }

--- a/tree/30_generic_methods/_classes_success.cf
+++ b/tree/30_generic_methods/_classes_success.cf
@@ -28,7 +28,12 @@
 bundle agent _classes_success(class_prefix)
 {
   vars:
-      "suffix" slist => { "ok", "reached", "kept" };
+      "prefix" slist => { "promise_kept" };
+      "suffix" slist => { "ok", "reached", "kept", "not_repaired" };
+
+      "${prefix}_local"
+        string     => "${prefix}_${class_prefix}",
+        classes    => always("${prefix}_${class_prefix}");
 
       "local_${suffix}"
         string     => "${class_prefix}_${suffix}",


### PR DESCRIPTION
Fixes #4344 - Add prefix to classes created by classes_success and classes_failure and add acceptance tests

cf http://www.rudder-project.org/redmine/issues/4344
