### PR TITLE
Fixes #4345 - Fix typo in bundle call class_success

### DIFF
--- a/tree/30_generic_methods/service_ensure_stopped.cf
+++ b/tree/30_generic_methods/service_ensure_stopped.cf
@@ -46,7 +46,7 @@ bundle agent service_ensure_stopped(service_name)
       # If service_check_running has no detected any process, it will not result
       # in a success so the result class of this promise should be the a success.
       "create success class"
-        usebundle => _classes_success("${class_prefix"),
+        usebundle => _classes_success("${class_prefix}"),
         ifvarclass => "!service_check_running_${canonified_service_name}_kept";
  
      # If service_check_running has detected a process, the process will be


### PR DESCRIPTION
Fixes #4345 - Fix typo in bundle call class_success

cf http://www.rudder-project.org/redmine/issues/4345
