### PR TITLE
Fixes #4489 - Use digest instead of mtime for file comparison

### DIFF
--- a/tree/30_generic_methods/file_copy_from_local_source_recursion.cf
+++ b/tree/30_generic_methods/file_copy_from_local_source_recursion.cf
@@ -46,12 +46,12 @@ bundle agent file_copy_from_local_source_recursion(source, destination, recursio
   files:
    !is_dir_copy::
       "${destination}"
-        copy_from    => ncf_local_cp_method("${source}", "mtime"),
+        copy_from    => ncf_local_cp_method("${source}", "digest"),
         classes      => classes_generic("${class_prefix}");
 
    is_dir_copy::
       "${destination}"
-        copy_from    => ncf_local_cp_method("${source}", "mtime"),
+        copy_from    => ncf_local_cp_method("${source}", "digest"),
         depth_search => recurse("${recursion}"),
         classes      => classes_generic("${class_prefix}");
 

--- a/tree/30_generic_methods/file_copy_from_remote_source_recursion.cf
+++ b/tree/30_generic_methods/file_copy_from_remote_source_recursion.cf
@@ -47,12 +47,12 @@ bundle agent file_copy_from_remote_source_recursion(source, destination, recursi
 
    !is_dir_copy::
       "${destination}"
-        copy_from    => ncf_remote_cp_method("${source}", "${sys.policy_hub}", "mtime"),
+        copy_from    => ncf_remote_cp_method("${source}", "${sys.policy_hub}", "digest"),
         classes      => classes_generic("${class_prefix}");
 
    is_dir_copy::
       "${destination}"
-        copy_from    => ncf_remote_cp_method("${source}", "${sys.policy_hub}", "mtime"),
+        copy_from    => ncf_remote_cp_method("${source}", "${sys.policy_hub}", "digest"),
         depth_search => recurse("${recursion}"),
         classes      => classes_generic("${class_prefix}");
 


### PR DESCRIPTION
Fixes #4489 - Use digest instead of mtime for file comparison
