### PR TITLE
Fixes #4784: enforce the complete class_prefix (and not only its start) ...

### DIFF
--- a/tree/30_generic_methods/logger_rudder.cf
+++ b/tree/30_generic_methods/logger_rudder.cf
@@ -41,7 +41,7 @@ bundle agent logger_rudder(message, class_prefix)
 
       # 3/ Once the final expected reports file has been expanded, read in our array
       "number_lines"
-        int        => getfields("^[^;]*;;${class_prefix}.*", "${expected_reports_file}", ";;", "report_data"),
+        int        => getfields("^[^;]*;;${class_prefix};;.*", "${expected_reports_file}", ";;", "report_data"),
         classes    => if_ok("report_data_read");
 
   files:


### PR DESCRIPTION
...for reporting, as several may start with the same text
