### PR TITLE
Fixes #4714: remove warning on cfengine bundle (a bundle common should n...

### DIFF
--- a/tree/60_services/cfengine/stable/cfengine.cf
+++ b/tree/60_services/cfengine/stable/cfengine.cf
@@ -1,4 +1,4 @@
-bundle common cfengine(path)
+bundle common cfengine
 {
   vars:
     "splay" string => "2";


### PR DESCRIPTION
...ot have parameter)
