### PR TITLE
Fixes #5381: Correct auto-escaping of method arguments to prevent breaka...

### DIFF
--- a/tests/unit/technique_metadata_test_content.cf
+++ b/tests/unit/technique_metadata_test_content.cf
@@ -1,0 +1,12 @@
+# @name ncf technique method argument escape test
+# @description This is a bundle to test ncf's Python lib
+# @version 0.1
+
+bundle agent content_escaping_test
+{
+  methods:
+    "method_call" usebundle => package_install_version("apache2", "2.2.11"),
+      ifvarclass => "any";
+    "method_call" usebundle => file_replace_lines("/etc/httpd/conf/httpd.conf", "ErrorLog \"/var/log/httpd/error_log\"", "ErrorLog \"/projet/logs/httpd/error_log\""),
+      ifvarclass => "redhat";
+}

--- a/tests/unit/test_ncf.py
+++ b/tests/unit/test_ncf.py
@@ -18,6 +18,16 @@ class TestNcf(unittest.TestCase):
     method_calls = ncf.parse_technique_methods(self.test_technique_file)
     self.technique_metadata['method_calls'] = method_calls
 
+    self.technique_metadata_test = { 'name': 'ncf technique method argument escape test', 'description': "This is a bundle to test ncf's Python lib", 'version': '0.1', 'bundle_name': 'content_escaping_test', 'bundle_args': [],
+        'method_calls': [
+            { 'method_name': 'package_install_version', 'args': ['apache2', '2.2.11'], 'class_context': 'any' },
+            { 'method_name': 'file_replace_lines', 'args': ['/etc/httpd/conf/httpd.conf', 'ErrorLog \"/var/log/httpd/error_log\"', 'ErrorLog "/projet/logs/httpd/error_log"'],  'class_context': 'redhat' },
+          ]
+        }
+    self.technique_metadata_test_content = os.path.realpath('technique_metadata_test_content.cf')
+    self.technique_test_expected_content = open(self.technique_metadata_test_content).read()
+
+
   def test_get_ncf_root_dir(self):
     self.assertEquals(ncf.get_root_dir(), os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + "/../../"))
 
@@ -275,6 +285,21 @@ class TestNcf(unittest.TestCase):
     # Clean
     shutil.rmtree(os.path.realpath(os.path.join("write_test", "50_techniques")))
     self.assertTrue(result)
+
+  def test_generate_technique_content(self):
+    """Check that generate_technique_content works correctly - including escaping " in arguments"""
+    content = ncf.generate_technique_content(self.technique_metadata_test)
+    self.assertEquals(self.technique_test_expected_content, content)
+
+  def test_parse_technique_methods_unescape_double_quotes(self):
+    test_parse_technique_methods_unescape_double_quotes_calls = ncf.parse_technique_methods(self.technique_metadata_test_content)
+    print test_parse_technique_methods_unescape_double_quotes_calls
+    expected_result = [
+                        { 'method_name': 'package_install_version', 'class_context': 'any', 'args': ['apache2', '2.2.11'] },
+                        { 'method_name': 'file_replace_lines', 'class_context': 'any', 'args': ['/etc/httpd/conf/httpd.conf', 'ErrorLog "/var/log/httpd/error_log"', 'ErrorLog "/projet/logs/httpd/error_log"'] }
+                      ]
+    self.assertEquals(expected_result, test_parse_technique_methods_unescape_double_quotes_calls)
+
     
   #####################################
   # Tests for detecting hooks

--- a/tools/ncf.py
+++ b/tools/ncf.py
@@ -189,7 +189,7 @@ def parse_technique_methods(technique_file):
         if attribute['lval'] == 'usebundle':
           if attribute['rval']['type'] == 'functionCall':
             method_name = attribute['rval']['name']
-            args = [arg['value'] for arg in attribute['rval']['arguments']]
+            args = [arg['value'].replace('\"', '"') for arg in attribute['rval']['arguments']]
           if attribute['rval']['type'] == 'string':
             method_name = attribute['rval']['value']
 
@@ -394,7 +394,7 @@ def generate_technique_content(technique_metadata):
     
     # Treat each argument of the method_call
     if 'args' in method_call:
-      args = ['"%s"'%arg for arg in method_call['args'] ]
+      args = ['"%s"'%re.sub(r'(?<!\)"', r'\"', arg) for arg in method_call['args'] ]
       arg_value = ', '.join(args)
     else:
       arg_value = ""


### PR DESCRIPTION
...ge when double quoted values are used in ncf builder

Co-Authored-By: Jonathan CLARKE jonathan.clarke@normation.com

Ticket: http://www.rudder-project.org/redmine/issues/5381

To be merged in master
