### PR TITLE
Fixes #5625: Fix for class eval optimizations in 3.6.1+

### DIFF
--- a/tree/10_ncf_internals/dispatcher.cf
+++ b/tree/10_ncf_internals/dispatcher.cf
@@ -28,6 +28,7 @@ bundle agent dispatcher
 {
   vars:
       "services" slist => { "@{mapper.services}" };
+      "cservices[${services}]" string => canonify("${services}");
 
   classes:
       "mapper_services_exists" expression => isvariable("mapper.services");
@@ -37,7 +38,8 @@ bundle agent dispatcher
       # key 1 is the base (relative to 60_services)
       # key 2 is the service name
       # key 3 is the service version  (oldstable, stable, testing, unstable)
-      "services_array_defined" expression => regextract("(.*)/([^/]+)/([^/]+)", "${services}", "services_array_${services}");
+      "${cservices[${services}]}_array_defined" expression => regextract("(.*)/([^/]+)/([^/]+)", "${services}", "services_array_${services}");
+      "services_array_defined" expression => classmatch(".*_array_defined");
 
   methods:
     services_array_defined.dispatcher_reports_reached::


### PR DESCRIPTION
In 3.6.1+ a class evaluation optimization was introduced that prevents
the `services_array_defined` class from being re-evaluated several times
in a loop, so the `regextract()` is only evaluated for the first service
defined. To fix this, we define per-service classes, and define
`services_array_defined` using `classmatch()` on those.
