### PR TITLE
Fixes #4971: Do not use the group 'nogroup' in tests (not here everywher...

### DIFF
--- a/tests/acceptance/30_generic_methods/permissions.cf
+++ b/tests/acceptance/30_generic_methods/permissions.cf
@@ -27,7 +27,7 @@ bundle agent init
     "file_canon" string => canonify("${file}");
     "mode"       string => "640";
     "owner"      string => "nobody";
-    "group"      string => "nogroup";
+    "group"      string => "daemon";
 
   files:
     "${file}"

--- a/tests/acceptance/30_generic_methods/permissions_dirs.cf
+++ b/tests/acceptance/30_generic_methods/permissions_dirs.cf
@@ -27,7 +27,7 @@ bundle agent init
     "directory_canon" string => canonify("${directory}");
     "mode"            string => "750";
     "owner"           string => "nobody";
-    "group"           string => "nogroup";
+    "group"           string => "daemon";
 
   files:
     "${directory}/."

--- a/tests/acceptance/30_generic_methods/permissions_dirs_recurse.cf
+++ b/tests/acceptance/30_generic_methods/permissions_dirs_recurse.cf
@@ -27,7 +27,7 @@ bundle agent init
     "directory_canon" string => canonify("${directory}");
     "mode"            string => "750";
     "owner"           string => "nobody";
-    "group"           string => "nogroup";
+    "group"           string => "daemon";
 
   files:
     "${directory}/."

--- a/tests/acceptance/30_generic_methods/permissions_mode_multiple_existing_dirs.cf
+++ b/tests/acceptance/30_generic_methods/permissions_mode_multiple_existing_dirs.cf
@@ -27,7 +27,7 @@ bundle agent init
     "directory_canon" string => canonify("${directory}");
     "mode"            string => "750";
     "owner"           string => "nobody";
-    "group"           string => "nogroup";
+    "group"           string => "daemon";
     "type"            string => "directories";
     "recursion"       string => "inf";
 

--- a/tests/acceptance/30_generic_methods/permissions_mode_multiple_existing_files.cf
+++ b/tests/acceptance/30_generic_methods/permissions_mode_multiple_existing_files.cf
@@ -27,7 +27,7 @@ bundle agent init
     "directory_canon" string => canonify("${directory}");
     "mode"            string => "750";
     "owner"           string => "nobody";
-    "group"           string => "nogroup";
+    "group"           string => "daemon";
     "type"            string => "files";
     "recursion"       string => "inf";
 

--- a/tests/acceptance/30_generic_methods/permissions_mode_single_existing_dir.cf
+++ b/tests/acceptance/30_generic_methods/permissions_mode_single_existing_dir.cf
@@ -27,7 +27,7 @@ bundle agent init
     "directory_canon" string => canonify("${directory}");
     "mode"            string => "750";
     "owner"           string => "nobody";
-    "group"           string => "nogroup";
+    "group"           string => "daemon";
     "type"            string => "directories";
     "recursion"       string => "0";
 

--- a/tests/acceptance/30_generic_methods/permissions_mode_single_existing_file.cf
+++ b/tests/acceptance/30_generic_methods/permissions_mode_single_existing_file.cf
@@ -27,7 +27,7 @@ bundle agent init
     "file_canon" string => canonify("${file}");
     "mode"       string => "640";
     "owner"      string => "nobody";
-    "group"      string => "nogroup";
+    "group"      string => "daemon";
     "type"       string => "files";
     "recursion"  string => "0";
 

--- a/tests/acceptance/30_generic_methods/permissions_recurse.cf
+++ b/tests/acceptance/30_generic_methods/permissions_recurse.cf
@@ -27,7 +27,7 @@ bundle agent init
     "directory_canon" string => canonify("${directory}");
     "mode"            string => "750";
     "owner"           string => "nobody";
-    "group"           string => "nogroup";
+    "group"           string => "daemon";
 
   files:
     "${directory}/."


### PR DESCRIPTION
...e)

Ticket: https://www.rudder-project.org/redmine/issues/4971

To be merged in master
