### PR TITLE
use long option names in Quickstart

### DIFF
--- a/site/content/Quickstart.md
+++ b/site/content/Quickstart.md
@@ -66,7 +66,7 @@ Let's create a technique to force bash timeout on servers:
 
 Test it, run:
 
-    cf-agent -KI
+    cf-agent --no-lock --inform
     grep TMOUT /etc/profile
 
 Yep, it works !


### PR DESCRIPTION
When I write documentation I always use the long format of options. Even in shell scripts I prefer the long option since I might come back and have to read the script.

I use the short format of options only when I directly work in the shell.