### PR TITLE
Fix test to reflect pass on AIX

### DIFF
--- a/tests/acceptance/30_generic_methods/file_copy_from_local_source.cf
+++ b/tests/acceptance/30_generic_methods/file_copy_from_local_source.cf
@@ -28,8 +28,8 @@ bundle agent init
     "destination_file_canon" string => canonify("${destination_file}");
 
     "mode"                   string => "644";
-    "owner"                  string => "root";
-    "group"                  string => "root";
+    "owner"                  string => "0";
+    "group"                  string => "0";
 
   files:
     "${source_file}"
@@ -51,9 +51,13 @@ bundle agent test
 bundle agent check
 {
   vars:
-    "permissions_test_mode"  string => "/usr/bin/test $(/usr/bin/stat -c %a ${init.destination_file}) = \"${init.mode}\"";
-    "permissions_test_owner" string => "/usr/bin/test $(/usr/bin/stat -c %U ${init.destination_file}) = \"${init.owner}\"";
-    "permissions_test_group" string => "/usr/bin/test $(/usr/bin/stat -c %G ${init.destination_file}) = \"${init.group}\"";
+    aix::
+      "stat_path" string => "/usr/bin/istat";
+    any::
+      "stat_path" string => "/usr/bin/stat";
+    "permissions_test_mode"  string => "/usr/bin/test $($(stat_path) -c %a ${init.destination_file}) = \"${init.mode}\"";
+    "permissions_test_owner" string => "/usr/bin/test $($(stat_path) -c %U ${init.destination_file}) = \"${init.owner}\"";
+    "permissions_test_group" string => "/usr/bin/test $($(stat_path) -c %G ${init.destination_file}) = \"${init.group}\"";
 
   classes:
     # By default, file_copy_from_local_source_type_recursion should create the file if it doesn't exist

--- a/tests/acceptance/30_generic_methods/file_copy_from_local_source_recursion.cf
+++ b/tests/acceptance/30_generic_methods/file_copy_from_local_source_recursion.cf
@@ -52,9 +52,13 @@ bundle agent test
 bundle agent check
 {
   vars:
-    "permissions_test_mode"  string => "/usr/bin/test $(/usr/bin/stat -c %a ${init.destination_file}) = \"${init.mode}\"";
-    "permissions_test_owner" string => "/usr/bin/test $(/usr/bin/stat -c %U ${init.destination_file}) = \"${init.owner}\"";
-    "permissions_test_group" string => "/usr/bin/test $(/usr/bin/stat -c %G ${init.destination_file}) = \"${init.group}\"";
+  aix::
+      "stat_path" string => "/usr/bin/istat";
+    any::
+      "stat_path" string => "/usr/bin/stat";
+    "permissions_test_mode"  string => "/usr/bin/test $($(stat_path) -c %a ${init.destination_file}) = \"${init.mode}\"";
+    "permissions_test_owner" string => "/usr/bin/test $($(stat_path) -c %U ${init.destination_file}) = \"${init.owner}\"";
+    "permissions_test_group" string => "/usr/bin/test $($(stat_path) -c %G ${init.destination_file}) = \"${init.group}\"";
 
   classes:
     # By default, file_copy_from_local_source_type_recursion should create the file if it doesn't exist

--- a/tests/acceptance/30_generic_methods/permissions.cf
+++ b/tests/acceptance/30_generic_methods/permissions.cf
@@ -32,7 +32,7 @@ bundle agent init
   files:
     "${file}"
       create => "true",
-      perms  => mog("000", "root", "root");
+      perms  => mog("000", "root", "0");
 
 }
 
@@ -49,9 +49,13 @@ bundle agent test
 bundle agent check
 {
   vars:
-    "permissions_test_mode"  string => "/usr/bin/test $(/usr/bin/stat -c %a ${init.file}) = \"${init.mode}\"";
-    "permissions_test_owner" string => "/usr/bin/test $(/usr/bin/stat -c %U ${init.file}) = \"${init.owner}\"";
-    "permissions_test_group" string => "/usr/bin/test $(/usr/bin/stat -c %G ${init.file}) = \"${init.group}\"";
+    aix::
+      "stat_path" string => "/usr/bin/istat";
+    any::
+      "stat_path" string => "/usr/bin/stat";
+    "permissions_test_mode"  string => "/usr/bin/test $($(stat_path) -c %a ${init.file}) = \"${init.mode}\"";
+    "permissions_test_owner" string => "/usr/bin/test $($(stat_path) -c %U ${init.file}) = \"${init.owner}\"";
+    "permissions_test_group" string => "/usr/bin/test $($(stat_path) -c %G ${init.file}) = \"${init.group}\"";
 
   classes:
     # By default, permissions_type_recursion should create the file if it doesn't exist

--- a/tests/acceptance/30_generic_methods/permissions_dirs.cf
+++ b/tests/acceptance/30_generic_methods/permissions_dirs.cf
@@ -32,7 +32,7 @@ bundle agent init
   files:
     "${directory}/."
       create => "true",
-      perms  => mog("000", "root", "root");
+      perms  => mog("000", "root", "0");
 
 }
 
@@ -49,9 +49,13 @@ bundle agent test
 bundle agent check
 {
   vars:
-    "permissions_test_mode"  string => "/usr/bin/test $(/usr/bin/stat -c %a ${init.directory}) = \"${init.mode}\"";
-    "permissions_test_owner" string => "/usr/bin/test $(/usr/bin/stat -c %U ${init.directory}) = \"${init.owner}\"";
-    "permissions_test_group" string => "/usr/bin/test $(/usr/bin/stat -c %G ${init.directory}) = \"${init.group}\"";
+    aix::
+      "path_stat" string => "/usr/bin/istat";
+    any::
+      "path_stat" string => "/usr/bin/stat";
+    "permissions_test_mode"  string => "/usr/bin/test $($(path_stat) -c %a ${init.directory}) = \"${init.mode}\"";
+    "permissions_test_owner" string => "/usr/bin/test $($(path_stat) -c %U ${init.directory}) = \"${init.owner}\"";
+    "permissions_test_group" string => "/usr/bin/test $($(path_stat) -c %G ${init.directory}) = \"${init.group}\"";
 
   classes:
     # By default, permissions_type_recursion should create the directory if it doesn't exist

--- a/tests/acceptance/30_generic_methods/permissions_mode_single_existing_dir.cf
+++ b/tests/acceptance/30_generic_methods/permissions_mode_single_existing_dir.cf
@@ -34,7 +34,7 @@ bundle agent init
   files:
     "${directory}/."
       create => "true",
-      perms  => mog("000", "root", "root");
+      perms  => mog("000", "root", "0");
 
 }
 
@@ -51,9 +51,13 @@ bundle agent test
 bundle agent check
 {
   vars:
-    "permissions_test_mode"  string => "/usr/bin/test $(/usr/bin/stat -c %a ${init.directory}) = \"${init.mode}\"";
-    "permissions_test_owner" string => "/usr/bin/test $(/usr/bin/stat -c %U ${init.directory}) = \"${init.owner}\"";
-    "permissions_test_group" string => "/usr/bin/test $(/usr/bin/stat -c %G ${init.directory}) = \"${init.group}\"";
+    aix::
+      "path_stat" string => "/usr/bin/istat";
+    any::
+      "path_stat" string => "/usr/bin/stat";
+    "permissions_test_mode"  string => "/usr/bin/test $($(path_stat) -c %a ${init.directory}) = \"${init.mode}\"";
+    "permissions_test_owner" string => "/usr/bin/test $($(path_stat) -c %U ${init.directory}) = \"${init.owner}\"";
+    "permissions_test_group" string => "/usr/bin/test $($(path_stat) -c %G ${init.directory}) = \"${init.group}\"";
 
   classes:
     # By default, permissions_type_recursion should create the directory if it doesn't exist

--- a/tests/acceptance/30_generic_methods/permissions_mode_single_existing_file.cf
+++ b/tests/acceptance/30_generic_methods/permissions_mode_single_existing_file.cf
@@ -34,7 +34,7 @@ bundle agent init
   files:
     "${file}"
       create => "true",
-      perms  => mog("000", "root", "root");
+      perms  => mog("000", "root", "0");
 
 }
 
@@ -51,9 +51,13 @@ bundle agent test
 bundle agent check
 {
   vars:
-    "permissions_test_mode"  string => "/usr/bin/test $(/usr/bin/stat -c %a ${init.file}) = \"${init.mode}\"";
-    "permissions_test_owner" string => "/usr/bin/test $(/usr/bin/stat -c %U ${init.file}) = \"${init.owner}\"";
-    "permissions_test_group" string => "/usr/bin/test $(/usr/bin/stat -c %G ${init.file}) = \"${init.group}\"";
+    aix::
+      "stat_path" string => "/usr/bin/istat";
+    any::
+      "stat_path" string => "/usr/bin/stat";
+    "permissions_test_mode"  string => "/usr/bin/test $($(stat_path) -c %a ${init.file}) = \"${init.mode}\"";
+    "permissions_test_owner" string => "/usr/bin/test $($(stat_path) -c %U ${init.file}) = \"${init.owner}\"";
+    "permissions_test_group" string => "/usr/bin/test $($(stat_path) -c %G ${init.file}) = \"${init.group}\"";
 
   classes:
     # By default, permissions_type_recursion should create the file if it doesn't exist


### PR DESCRIPTION
AIX does not have /usr/bin/stat, it has /usr/bin/istat. Preferred solution is ```path[stat]```, but it's not clear to me how to implement within the acceptance tests. (note, multiple files receiving same fix.)