### PR TITLE
Service disabled boot

### DIFF
--- a/tree/30_generic_methods/service_check_started_at_boot.cf
+++ b/tree/30_generic_methods/service_check_started_at_boot.cf
@@ -33,7 +33,7 @@ bundle agent service_check_started_at_boot(service_name)
       "command_to_check"   string => "${paths.path[systemctl]} is-enabled ${service_name}";
 
     !systemctl_utility_present.chkconfig_utility_present::
-      "command_to_check"   string => "${paths.path[chkconfig]} --list ${service_name} | grep -q 3:on";
+      "command_to_check"   string => "${paths.path[chkconfig]} --list ${service_name} | grep -q -e 3:on -e B:on";
 
     !systemctl_utility_present.!chkconfig_utility_present::
       "command_to_check"   string => "${paths.path[test]} -f /etc/rc`runlevel | ${paths.path[cut]} -d' ' -f2`.d/S??${service_name}";

--- a/tree/30_generic_methods/service_check_stopped_at_boot.cf
+++ b/tree/30_generic_methods/service_check_stopped_at_boot.cf
@@ -1,0 +1,64 @@
+#####################################################################################
+# Copyright 2014 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name Service check at boot
+# @description Check if a service is set to not start at boot using the appropriate method
+#
+# @parameter service_name  Service name (as recognized by systemd, init.d, etc...)
+# 
+# @class_prefix service_check_stopped_at_boot
+# @class_parameter service_name
+# This bundle will define a class service_check_stopped_at_boot_${service_name}_{kept,ok,not_ok,failed,reached}
+
+bundle agent service_check_stopped_at_boot(service_name)
+{
+  vars:
+
+    systemctl_utility_present::
+      "command_to_check"   string => "${paths.path[systemctl]} is-enabled ${service_name}  | grep -q disabled";
+
+    !systemctl_utility_present.chkconfig_utility_present::
+      "command_to_check"   string => "${paths.path[chkconfig]} --list ${service_name} | grep -q 3:off";
+
+    # This case probably doesn't work!
+    #!systemctl_utility_present.!chkconfig_utility_present::
+    #  "command_to_check"   string => "${paths.path[test]} -f /etc/rc`runlevel | ${paths.path[cut]} -d' ' -f2`.d/S??${service_name}";
+
+    any::
+
+      "canonified_service_name" string => canonify("${service_name}");
+      "canonified_command"      string => canonify("${command_to_check}");
+
+      "class_prefix"            string => "service_check_stopped_at_boot_${canonified_service_name}";
+
+  methods:
+
+      "check_run"
+        usebundle => command_execution("${command_to_check}");
+
+      "success" usebundle => _classes_success("${class_prefix}"),
+        ifvarclass => "command_execution_${canonified_command}_repaired.!command_execution_${canonified_command}_failed";
+
+      "failure" usebundle => _classes_failure("${class_prefix}"),
+        ifvarclass => "command_execution_${canonified_command}_failed";
+
+    any::
+
+      "reports" usebundle => _logger("Ensure that service ${service_name} is disabled at boot", "${class_prefix}");
+
+}

--- a/tree/30_generic_methods/service_ensure_stopped_at_boot.cf
+++ b/tree/30_generic_methods/service_ensure_stopped_at_boot.cf
@@ -1,0 +1,75 @@
+#####################################################################################
+# Copyright 2014 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name Service ensure disabled at boot
+# @description Force a service not to be started at boot
+#
+# @parameter service_name Service name (as recognized by systemd, init.d, Windows, etc...)
+#
+# @class_prefix service_ensure_stopped_at_boot
+# @class_parameter service_name
+# This bundle will define a class service_ensure_stopped_at_boot_${canonified_service_name}_{kept,repaired,not_ok,ok,reached}
+
+bundle agent service_ensure_stopped_at_boot(service_name)
+{
+  vars:
+
+    systemctl_utility_present::
+      "command_to_register" string => "${paths.path[systemctl]} disable ${service_name}";
+
+    !systemctl_utility_present.chkconfig_utility_present::
+      "command_to_register" string => "${paths.path[chkconfig]} ${service_name} off";
+    !systemctl_utility_present.update_rcd_utility_present::
+      "command_to_register" string => "${paths.path[update_rcd]} ${service_name} disable";
+
+    any::
+
+      "canonified_service_name" string => canonify("${service_name}");
+      "canonified_command_name" string => canonify("${command_to_register}");
+
+      "class_prefix"            string => "service_ensure_stopped_at_boot_${canonified_service_name}";
+
+  methods:
+    !windows::
+      "check_at_boot"
+        usebundle => service_check_stopped_at_boot("${service_name}");
+
+      "define_at_boot"
+        usebundle  => command_execution("${service_ensure_stopped_at_boot.command_to_register}"),
+        ifvarclass => "service_check_stopped_at_boot_${canonified_service_name}_not_ok";
+
+      "already defined"
+        usebundle => _classes_success("${class_prefix}"),
+        ifvarclass => "service_check_stopped_at_boot_${canonified_service_name}_ok";
+
+      "copy classes"
+        usebundle  => _classes_copy("command_execution_${canonified_command_name}", "${class_prefix}"),
+        ifvarclass => "service_check_stopped_at_boot_${canonified_service_name}_not_ok";
+
+   any::
+      "report"
+        usebundle => _logger("Ensure service ${service_name} is disabled at boot", "${class_prefix}"),
+       ifvarclass => "${class_prefix}_reached";
+
+  services:
+    windows::
+      "${service_name}"
+        service_policy => "stop",
+        service_method => bootstart,
+        classes        => classes_generic("${class_prefix}");
+}


### PR DESCRIPTION
This allows to check that chkconfig servicename off has been set, needed to verify a service is in fact disabled.
This allows to disable a service at boot time.
