### PR TITLE
Fixes #6940: The service_check_started_at_boot generic method fails if run on Debian 8 and a legacy sysv init script is present

### DIFF
--- a/tree/30_generic_methods/service_check_started_at_boot.cf
+++ b/tree/30_generic_methods/service_check_started_at_boot.cf
@@ -20,7 +20,7 @@
 # @description Check if a service is set to start at boot using the appropriate method
 #
 # @parameter service_name  Service name (as recognized by systemd, init.d, etc...)
-# 
+#
 # @class_prefix service_check_started_at_boot
 # @class_parameter service_name
 # This bundle will define a class service_check_started_at_boot_${service_name}_{kept,ok,not_ok,failed,reached}
@@ -29,13 +29,13 @@ bundle agent service_check_started_at_boot(service_name)
 {
   vars:
 
-    systemctl_utility_present::
+    pass2.systemctl_utility_present.!broken_systemctl::
       "command_to_check"   string => "${paths.path[systemctl]} is-enabled ${service_name}";
 
-    !systemctl_utility_present.chkconfig_utility_present::
+    pass2.!systemctl_utility_present.chkconfig_utility_present::
       "command_to_check"   string => "${paths.path[chkconfig]} --list ${service_name} | grep -q -e 3:on -e B:on";
 
-    !systemctl_utility_present.!chkconfig_utility_present::
+    pass2.(!(systemctl_utility_present|chkconfig_utility_present)|broken_systemctl)::
       "command_to_check"   string => "${paths.path[test]} -f /etc/rc`runlevel | ${paths.path[cut]} -d' ' -f2`.d/S??${service_name}";
 
     any::
@@ -45,7 +45,20 @@ bundle agent service_check_started_at_boot(service_name)
 
       "class_prefix"            string => "service_check_started_at_boot_${canonified_service_name}";
 
+  classes:
+
+      "pass2"               expression => "pass1";
+      "pass1"               expression => "any";
+
+      # This is to workaround a bug in Debian Jessie, that makes systemctl is-enabled
+      # fail if run against a service that still uses SysV style scripts
+      # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=760616
+      "init_script_present" expression => fileexists("/etc/init.d/${service_name}");
+      "broken_systemctl"    expression => "debian_8.init_script_present";
+
   methods:
+
+    pass2::
 
       "check_run"
         usebundle => command_execution("${command_to_check}");
@@ -55,8 +68,6 @@ bundle agent service_check_started_at_boot(service_name)
 
       "failure" usebundle => _classes_failure("${class_prefix}"),
         ifvarclass => "command_execution_${canonified_command}_failed";
-
-    any::
 
       "reports" usebundle => _logger("Ensure that service ${service_name} is defined at boot", "${class_prefix}");
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/6940