### PR TITLE
Fixes #7168: ncf debian package is missing asciidoc build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: ncf
 Section: admin
 Priority: extra
 Maintainer: Rudder packaging team <rudder-packaging@rudder-project.org>
-Build-Depends: debhelper (>= 7)
+Build-Depends: debhelper (>= 7), python, asciidoc, libxml2-utils, xsltproc, docbook-xml, docbook-xsl
 Standards-Version: 3.8.0
 Homepage: http://www.ncf.io
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7168