### PR TITLE
Fixes #7436: Techniques that call _logger, _logger_default or logger_rudder will break because these methods take 4 arguments now and no upgrade path has been planned

### DIFF
--- a/tests/style/30_generic_methods/all_generic_methods_should_use_new_style_log_calls.sh
+++ b/tests/style/30_generic_methods/all_generic_methods_should_use_new_style_log_calls.sh
@@ -23,7 +23,7 @@ set -e
 
 FILES_TO_CHECK=`find "${NCF_TREE}/30_generic_methods/" -name "*.cf"`
 NB_ERROR=0
-for f in $FILES_TO_CHECK
+for f in ${FILES_TO_CHECK}
 do
   NB_BUNDLE=$(egrep "[^#]*usebundle\s*=>\s*_?logger(_default|_rudder|)\(" $f | wc -l)
   if [ $NB_BUNDLE -ne 0 ]; then

--- a/tests/style/30_generic_methods/all_generic_methods_should_use_new_style_log_calls.sh
+++ b/tests/style/30_generic_methods/all_generic_methods_should_use_new_style_log_calls.sh
@@ -1,5 +1,7 @@
+#!/bin/sh
+
 #####################################################################################
-# Copyright 2014 Normation SAS
+# Copyright 2015 Normation SAS
 #####################################################################################
 #
 # This program is free software: you can redistribute it and/or modify
@@ -15,28 +17,25 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #####################################################################################
+set -e
 
-# @name File create
-# @description Create a file if it doesn't exist
-#
-# @parameter target     File to create
-#
-# @class_prefix file_create
-# @class_parameter target
-# This bundle will define a class file_create_${target}_{kept,repaired,not_ok,ok,reached}
+# Check that all generic_methods use the new _log interface with 4 args and not the old _logger interface with 2 args
 
-bundle agent file_create(target)
-{
-  vars:
-    "old_class_prefix" string => canonify("file_create_${target}");
-    "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
-    "args"              slist => { "${target}" };
+FILES_TO_CHECK=`find "${NCF_TREE}/30_generic_methods/" -name "*.cf"`
+NB_ERROR=0
+for f in $FILES_TO_CHECK
+do
+  NB_BUNDLE=$(egrep "[^#]*usebundle\s*=>\s*_?logger(_default|_rudder|)\(" $f | wc -l)
+  if [ $NB_BUNDLE -ne 0 ]; then
+    echo "File $f uses deprecated _logger interface"
+    NB_ERROR=`expr $NB_ERROR + 1`
+  fi
+done
 
-  files:
-    "${target}"
-      create        => "true",
-      classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
+if [ $NB_ERROR -eq 0 ]; then
+  echo "R: $0 Pass"
+else
+  echo "R: $0 Fail"
+fi
 
-  methods:
-    "report" usebundle => _log("Create file ${target}", "${old_class_prefix}", "${class_prefix}", @{args});
-}
+exit $NB_ERROR

--- a/tests/unit/test_methods/30_generic_methods/test_generic_method.cf
+++ b/tests/unit/test_methods/30_generic_methods/test_generic_method.cf
@@ -18,13 +18,15 @@
 bundle agent test_generic_method(test_arg1, test_arg2)
 {
   vars:
-   "class_prefix"     string => canonify("test_generic_method_${test_arg1}");
+   "old_class_prefix"  string => canonify("test_generic_method_${test_arg1}");
+   "class_prefix"      string => canonify(join("_", "this.callers_promisers"));
+   "args"               slist => { "${test_arg1}", "${test_arg2}" };
 
   packages:
     "${package_name}" package_action => "add";
 
   methods:
     "success"         usebundle => _classes_success("${class_prefix}");
-    "report"          usebundle => _logger("Test Generic Method ${service_name}", "${class_prefix}");
+    "report"          usebundle => _log("Test Generic Method ${service_name}", "${old_class_prefix}", "${class_prefix}", @{args});
 
 }

--- a/tree/30_generic_methods/_log.cf
+++ b/tree/30_generic_methods/_log.cf
@@ -1,5 +1,5 @@
 #####################################################################################
-# Copyright 2013 Normation SAS
+# Copyright 2013-2015 Normation SAS
 #####################################################################################
 #
 # This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
 #
 #####################################################################################
 
-# @name Logger
+# @name Log
 # @description Standard logging output
 #
 # @parameter message              The common part of the message to display
@@ -29,11 +29,11 @@
 # The three states are kept, repaired and not_ok
 # (as defined in the classes_generic of the cfengine_stdlib)
 
-bundle agent _logger(message, old_class_prefix, origin_class_prefix, args)
+bundle agent _log(message, old_class_prefix, origin_class_prefix, args)
 {
   methods:
       # Report using the appropriate bundle(s)
-      "${configuration.enabled_loggers}"
+      "wrapper for ${configuration.enabled_loggers}"
         usebundle => ${configuration.enabled_loggers}("${message}", "${old_class_prefix}", "${origin_class_prefix}", "@{args}"),
         comment   => "Call the ${method} bundle with arguments ${old_class_prefix}, ${origin_class_prefix}, @{args}";
 }

--- a/tree/30_generic_methods/_log_default.cf
+++ b/tree/30_generic_methods/_log_default.cf
@@ -1,5 +1,5 @@
 #####################################################################################
-# Copyright 2013 Normation SAS
+# Copyright 2013-5 Normation SAS
 #####################################################################################
 #
 # This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
 #
 #####################################################################################
 
-# @name Logger default
+# @name Log default
 # @description Standard default logging output
 #
 # @parameter message              The common part of the message to display
@@ -29,14 +29,14 @@
 # The three states are kept, repaired and not_ok
 # (as defined in the classes_generic of the cfengine_stdlib)
 
-bundle agent _logger_default(message, old_class_prefix, origin_class_prefix, args)
+bundle agent _log_default(message, old_class_prefix, origin_class_prefix, args)
 {
   vars:
     "canonified_prefix" string => canonify("${old_class_prefix}");
 
     "promiser_count" int => length("this.callers_promisers");
 
-    # head(length-2) -> remove logger call stack (_logger + _logger_default)
+    # head(length-2) -> remove logger call stack (_log + _log_default)
     "nologger_len" string => eval("${promiser_count}-2", "math", "infix");
     "promisers_list_nologger" slist => sublist("this.callers_promisers", "head", "${nologger_len}");
 

--- a/tree/30_generic_methods/_logger.cf
+++ b/tree/30_generic_methods/_logger.cf
@@ -21,15 +21,13 @@
 #
 # @parameter message              The common part of the message to display
 # @parameter old_class_prefix     The prefix of the class for different states (0.x version)
-# @parameter origin_class_prefix  The prefix of the class for different states (1.x version)
-# @parameter args                 The arguments used to call the generic method (slist)
 #
 # @class_prefix
 # @class_parameter old_class_prefix
 # The three states are kept, repaired and not_ok
 # (as defined in the classes_generic of the cfengine_stdlib)
 
-bundle agent _logger(message, old_class_prefix, origin_class_prefix, args)
+bundle agent _logger(message, old_class_prefix)
 {
   vars:
       "empty_slist" slist => { cf_null };

--- a/tree/30_generic_methods/_logger.cf
+++ b/tree/30_generic_methods/_logger.cf
@@ -1,0 +1,43 @@
+#####################################################################################
+# Copyright 2013-5 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name Logger - legacy interface (DEPRECATED)
+# @description Standard logging output. This interface is for compatiblity with older generic methods and techniques, and is replaced by _log.
+#
+# @parameter message              The common part of the message to display
+# @parameter old_class_prefix     The prefix of the class for different states (0.x version)
+# @parameter origin_class_prefix  The prefix of the class for different states (1.x version)
+# @parameter args                 The arguments used to call the generic method (slist)
+#
+# @class_prefix
+# @class_parameter old_class_prefix
+# The three states are kept, repaired and not_ok
+# (as defined in the classes_generic of the cfengine_stdlib)
+
+bundle agent _logger(message, old_class_prefix, origin_class_prefix, args)
+{
+  vars:
+      "empty_slist" slist => { cf_null };
+
+  methods:
+      "legacy _logger wrapper" usebundle => _log("${message}", "${old_class_prefix}", "", @{empty_slist});
+
+  reports:
+    cfengine::
+      "WARNING: DEPRECATED _logger interface called. Please use _log instead (${old_class_prefix}: ${message})";
+}

--- a/tree/30_generic_methods/_logger_default.cf
+++ b/tree/30_generic_methods/_logger_default.cf
@@ -21,19 +21,20 @@
 #
 # @parameter message              The common part of the message to display
 # @parameter old_class_prefix     The prefix of the class for different states (0.x version)
-# @parameter origin_class_prefix  The prefix of the class for different states (1.x version)
-# @parameter args                 The arguments used to call the generic method (slist)
 #
 # @class_prefix _logger_default
 # @class_parameter old_class_prefix
 # The three states are kept, repaired and not_ok
 # (as defined in the classes_generic of the cfengine_stdlib)
 
-bundle agent _logger_default(message, old_class_prefix, origin_class_prefix, args)
+bundle agent _logger_default(message, old_class_prefix)
 {
 
+  vars:
+      "empty_slist" slist => { cf_null };
+
   methods:
-      "legacy _logger_default wrapper" usebundle => _log_default("${message}", "${old_class_prefix}", "", "");
+      "legacy _logger_default wrapper" usebundle => _log_default("${message}", "${old_class_prefix}", "", @{empty_slist});
 
   reports:
     cfengine::

--- a/tree/30_generic_methods/_logger_default.cf
+++ b/tree/30_generic_methods/_logger_default.cf
@@ -1,0 +1,41 @@
+#####################################################################################
+# Copyright 2013-5 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name Logger default - legacy interface (DEPRECATED)
+# @description Standard default logging output. This interface is for compatiblity with older generic methods and techniques, and is replaced by _log_default.
+#
+# @parameter message              The common part of the message to display
+# @parameter old_class_prefix     The prefix of the class for different states (0.x version)
+# @parameter origin_class_prefix  The prefix of the class for different states (1.x version)
+# @parameter args                 The arguments used to call the generic method (slist)
+#
+# @class_prefix _logger_default
+# @class_parameter old_class_prefix
+# The three states are kept, repaired and not_ok
+# (as defined in the classes_generic of the cfengine_stdlib)
+
+bundle agent _logger_default(message, old_class_prefix, origin_class_prefix, args)
+{
+
+  methods:
+      "legacy _logger_default wrapper" usebundle => _log_default("${message}", "${old_class_prefix}", "", "");
+
+  reports:
+    cfengine::
+      "WARNING: DEPRECATED _logger_default interface called. Please use _log_default instead (${old_class_prefix}: ${message})";
+}

--- a/tree/30_generic_methods/command_execution.cf
+++ b/tree/30_generic_methods/command_execution.cf
@@ -34,7 +34,7 @@ bundle agent command_execution(command_name)
 
   methods:
       "report"
-        usebundle  => _logger("Execute the command ${command_name}", "${old_class_prefix}", "${class_prefix}", @{args}),
+        usebundle  => _log("Execute the command ${command_name}", "${old_class_prefix}", "${class_prefix}", @{args}),
         ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
 
   commands:

--- a/tree/30_generic_methods/command_execution_result.cf
+++ b/tree/30_generic_methods/command_execution_result.cf
@@ -43,7 +43,7 @@ bundle agent command_execution_result(command, kept_codes, repaired_codes)
 
   methods:
       "report"
-        usebundle  => _logger("Execute the command ${command}", "${old_class_prefix}", "${class_prefix}", @{args}),
+        usebundle  => _log("Execute the command ${command}", "${old_class_prefix}", "${class_prefix}", @{args}),
         ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
 
   commands:

--- a/tree/30_generic_methods/condition_from_command.cf
+++ b/tree/30_generic_methods/condition_from_command.cf
@@ -50,7 +50,7 @@ bundle agent condition_from_command(condition_prefix, command, true_codes, false
 
   methods:
       "report"
-        usebundle  => _logger("Execute the test command ${command} to create ${condition_prefix}_{true,false}", "${old_class_prefix}", "${class_prefix}", @{args}),
+        usebundle  => _log("Execute the test command ${command} to create ${condition_prefix}_{true,false}", "${old_class_prefix}", "${class_prefix}", @{args}),
         ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
 
   commands:

--- a/tree/30_generic_methods/condition_from_expression.cf
+++ b/tree/30_generic_methods/condition_from_expression.cf
@@ -53,5 +53,5 @@ bundle agent condition_from_expression(condition_prefix, condition_expression)
       "success" usebundle => _classes_success("${old_class_prefix}");
       "success" usebundle => _classes_success("${class_prefix}");
 
-      "report"  usebundle => _logger("Create the condition ${condition_prefix}_{true,false} with ${condition_expression}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"  usebundle => _log("Create the condition ${condition_prefix}_{true,false} with ${condition_expression}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/condition_from_expression_persistent.cf
+++ b/tree/30_generic_methods/condition_from_expression_persistent.cf
@@ -55,5 +55,5 @@ bundle agent condition_from_expression_persistent(condition_prefix, condition_ex
       "success" usebundle => _classes_success("${old_class_prefix}");
       "success" usebundle => _classes_success("${class_prefix}");
 
-      "report"  usebundle => _logger("Create the persistent condition ${condition_prefix}_{true,false} with ${condition_expression}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"  usebundle => _log("Create the persistent condition ${condition_prefix}_{true,false} with ${condition_expression}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/directory_check_exists.cf
+++ b/tree/30_generic_methods/directory_check_exists.cf
@@ -47,5 +47,5 @@ bundle agent directory_check_exists(directory_name)
       "directory_doesnt_exists" usebundle => _classes_failure("${class_prefix}");
 
     any::
-      "report"                  usebundle => _logger("Check if directory ${directory_name} exists", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"                  usebundle => _log("Check if directory ${directory_name} exists", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/directory_create.cf
+++ b/tree/30_generic_methods/directory_create.cf
@@ -38,5 +38,5 @@ bundle agent directory_create(target)
       classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
   methods:
-    "report"             usebundle => _logger("Create directory ${target}", "${old_class_prefix}", "${class_prefix}", @{args});
+    "report"             usebundle => _log("Create directory ${target}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_check_exists.cf
+++ b/tree/30_generic_methods/file_check_exists.cf
@@ -47,5 +47,5 @@ bundle agent file_check_exists(file_name)
       "file_dont_exists"   usebundle => _classes_failure("${class_prefix}");
 
     any::
-      "report"             usebundle => _logger("Check if ${file_name} exists", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"             usebundle => _log("Check if ${file_name} exists", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_copy_from_local_source.cf
+++ b/tree/30_generic_methods/file_copy_from_local_source.cf
@@ -36,5 +36,5 @@ bundle agent file_copy_from_local_source(source, destination)
       "copy without recursion" usebundle => file_copy_from_local_source_recursion("${source}", "${destination}", "0");
       "new result classes"     usebundle => _classes_copy("${class_prefix}_copy_without_recursion", "${class_prefix}");
 
-      "report"                 usebundle => _logger("Copying ${destination} from ${source}", "", "${class_prefix}", @{args});
+      "report"                 usebundle => _log("Copying ${destination} from ${source}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_copy_from_local_source_recursion.cf
+++ b/tree/30_generic_methods/file_copy_from_local_source_recursion.cf
@@ -62,9 +62,9 @@ bundle agent file_copy_from_local_source_recursion(source, destination, recursio
     # directory (to apply recursion) or a file
     iteration_2.!is_dir_copy::
       "report"
-        usebundle  => _logger("Copying ${destination} from ${source}", "${old_class_prefix}", "${class_prefix}", @{args});
+        usebundle  => _log("Copying ${destination} from ${source}", "${old_class_prefix}", "${class_prefix}", @{args});
 
     iteration_2.is_dir_copy::
       "report"
-        usebundle  => _logger("Copying ${destination} from ${source}, recursion level ${recursion}", "${old_class_prefix}", "${class_prefix}", @{args});
+        usebundle  => _log("Copying ${destination} from ${source}, recursion level ${recursion}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_copy_from_remote_source.cf
+++ b/tree/30_generic_methods/file_copy_from_remote_source.cf
@@ -36,5 +36,5 @@ bundle agent file_copy_from_remote_source(source, destination)
       "copy without recursion" usebundle => file_copy_from_remote_source_recursion("${source}", "${destination}", "0");
       "new result classes"     usebundle => _classes_copy("${class_prefix}_copy_without_recursion", "${class_prefix}");
 
-      "report"                 usebundle => _logger("Copying ${destination} from ${source}", "", "${class_prefix}", @{args});
+      "report"                 usebundle => _log("Copying ${destination} from ${source}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_copy_from_remote_source_recursion.cf
+++ b/tree/30_generic_methods/file_copy_from_remote_source_recursion.cf
@@ -63,9 +63,9 @@ bundle agent file_copy_from_remote_source_recursion(source, destination, recursi
     # directory (to apply recursion) or a file
     iteration_2.!is_dir_copy::
       "report"
-        usebundle    => _logger("Copying ${destination} from ${source}", "${old_class_prefix}", "${class_prefix}", @{args});
+        usebundle    => _log("Copying ${destination} from ${source}", "${old_class_prefix}", "${class_prefix}", @{args});
 
     iteration_2.is_dir_copy::
       "report"
-        usebundle    => _logger("Copying ${destination} from ${source}, recursion level ${recursion}", "${old_class_prefix}", "${class_prefix}", @{args});
+        usebundle    => _log("Copying ${destination} from ${source}, recursion level ${recursion}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_create_symlink.cf
+++ b/tree/30_generic_methods/file_create_symlink.cf
@@ -36,5 +36,5 @@ bundle agent file_create_symlink(source, destination)
       "create without enforce" usebundle => file_create_symlink_enforce("${source}", "${destination}", "false");
       "new result classes"     usebundle => _classes_copy("${class_prefix}_create_without_enforce", "${class_prefix}");
 
-      "report"                 usebundle => _logger("Symlink ${destination} targeting ${source}", "", "${class_prefix}", @{args});
+      "report"                 usebundle => _log("Symlink ${destination} targeting ${source}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_create_symlink_enforce.cf
+++ b/tree/30_generic_methods/file_create_symlink_enforce.cf
@@ -43,5 +43,5 @@ bundle agent file_create_symlink_enforce(source, destination, enforce)
                     comment           => "Create the ${destination} symlink pointing to ${source}";
 
   methods:
-      "report" usebundle => _logger("Symlink ${destination} targeting ${source}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report" usebundle => _log("Symlink ${destination} targeting ${source}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_create_symlink_force.cf
+++ b/tree/30_generic_methods/file_create_symlink_force.cf
@@ -36,5 +36,5 @@ bundle agent file_create_symlink_force(source, destination)
       "create with enforce"  usebundle => file_create_symlink_enforce("${source}", "${destination}", "true");
       "new result classes"   usebundle => _classes_copy("${class_prefix}_create_with_enforce", "${class_prefix}");
 
-      "report"               usebundle => _logger("Symlink ${destination} targeting ${source}", "", "${class_prefix}", @{args});
+      "report"               usebundle => _log("Symlink ${destination} targeting ${source}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_download.cf
+++ b/tree/30_generic_methods/file_download.cf
@@ -62,14 +62,14 @@ bundle agent file_download(source, destination)
 
       "new result classes"        usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}");
 
-      "report"                    usebundle => _logger("Download ${source} into ${destination}", "${old_class_prefix}", "${class_prefix}", @{args}),
+      "report"                    usebundle => _log("Download ${source} into ${destination}", "${old_class_prefix}", "${class_prefix}", @{args}),
                                  ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
 
     !_stdlib_path_exists_curl.!_stdlib_path_exists_wget.!file_exists::
 
       "force_failure_class"       usebundle => _classes_failure("${old_class_prefix}");
       "new result classes"        usebundle => _classes_failure("${class_prefix}");
-      "report"                    usebundle => _logger("Unable to download ${source}: neither wget or curl are installed", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"                    usebundle => _log("Unable to download ${source}: neither wget or curl are installed", "${old_class_prefix}", "${class_prefix}", @{args});
 
     file_exists::
 
@@ -77,7 +77,7 @@ bundle agent file_download(source, destination)
                                  ifvarclass => "!command_execution_${canonified_action_command}_repaired";
       "new result classes"        usebundle => _classes_success("${class_prefix}"),
                                  ifvarclass => "!${class_prefix}_action_repaired";
-      "report"                    usebundle => _logger("File ${destination} already downloaded", "${old_class_prefix}", "${class_prefix}", @{args}),
+      "report"                    usebundle => _log("File ${destination} already downloaded", "${old_class_prefix}", "${class_prefix}", @{args}),
                                  ifvarclass => "(!has_promiser_stack.!command_execution_${canonified_action_command}_repaired)|(has_promiser_stack.!${class_prefix}_action_repaired)";
 
 }

--- a/tree/30_generic_methods/file_enforce_content.cf
+++ b/tree/30_generic_methods/file_enforce_content.cf
@@ -42,5 +42,5 @@ bundle agent file_enforce_content(file, lines, enforce)
         classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
   methods:
-      "report" usebundle => _logger("Insert content ${lines} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report" usebundle => _log("Insert content ${lines} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_ensure_block_in_section.cf
+++ b/tree/30_generic_methods/file_ensure_block_in_section.cf
@@ -43,5 +43,5 @@ bundle agent file_ensure_block_in_section(file, section_start, section_end, bloc
         classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
   methods:
-      "report" usebundle => _logger("Insert text block ${block} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report" usebundle => _log("Insert text block ${block} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_ensure_block_present.cf
+++ b/tree/30_generic_methods/file_ensure_block_present.cf
@@ -41,5 +41,5 @@ bundle agent file_ensure_block_present(file, block)
         classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
   methods:
-      "report" usebundle => _logger("Insert text block ${block} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report" usebundle => _log("Insert text block ${block} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_ensure_key_value_present_in_ini_section.cf
+++ b/tree/30_generic_methods/file_ensure_key_value_present_in_ini_section.cf
@@ -32,7 +32,10 @@
 bundle agent file_ensure_key_value_present_in_ini_section(file, section, name, value)
 {
   vars:
-      "class_prefix" string => canonify("file_ensure_key_value_present_in_ini_section_${file}");
+      "old_class_prefix" string => canonify("file_ensure_key_value_present_in_ini_section_${file}");
+      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "args"              slist => { "${file}", "${section}", "${name}", "${value}" };
+
       "content[${section}][${name}]" string => "${value}";
 
   files:
@@ -44,6 +47,6 @@ bundle agent file_ensure_key_value_present_in_ini_section(file, section, name, v
 
   methods:
       "report"
-        usebundle  => _log("Set line ${name}=${value} in section ${section} into ${file}", "${class_prefix}");
+        usebundle  => _log("Set line ${name}=${value} in section ${section} into ${file}", "${class_prefix}", "${class_prefix}", @{args});
 }
 

--- a/tree/30_generic_methods/file_ensure_key_value_present_in_ini_section.cf
+++ b/tree/30_generic_methods/file_ensure_key_value_present_in_ini_section.cf
@@ -44,6 +44,6 @@ bundle agent file_ensure_key_value_present_in_ini_section(file, section, name, v
 
   methods:
       "report"
-        usebundle  => _logger("Set line ${name}=${value} in section ${section} into ${file}", "${class_prefix}");
+        usebundle  => _log("Set line ${name}=${value} in section ${section} into ${file}", "${class_prefix}");
 }
 

--- a/tree/30_generic_methods/file_ensure_keys_values.cf
+++ b/tree/30_generic_methods/file_ensure_keys_values.cf
@@ -43,5 +43,5 @@ bundle agent file_ensure_keys_values(file, keys, separator)
         classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
   methods:
-      "report" usebundle => _logger("Ensure lines in format key${separator}values into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report" usebundle => _log("Ensure lines in format key${separator}values into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_ensure_line_present_in_ini_section.cf
+++ b/tree/30_generic_methods/file_ensure_line_present_in_ini_section.cf
@@ -59,5 +59,5 @@ bundle agent file_ensure_line_present_in_ini_section(file, section, line)
         classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
   methods:
-      "report" usebundle => _logger("Insert line(s) ${line} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report" usebundle => _log("Insert line(s) ${line} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_ensure_line_present_in_xml_tag.cf
+++ b/tree/30_generic_methods/file_ensure_line_present_in_xml_tag.cf
@@ -53,5 +53,5 @@ bundle agent file_ensure_line_present_in_xml_tag(file, tag, line)
       "failure" usebundle => _classes_failure("${class_prefix}");
 
     any::
-      "report"             usebundle => _logger("Insert line(s) ${line} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"             usebundle => _log("Insert line(s) ${line} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_ensure_lines_absent.cf
+++ b/tree/30_generic_methods/file_ensure_lines_absent.cf
@@ -41,5 +41,5 @@ bundle agent file_ensure_lines_absent(file, lines)
         classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
   methods:
-      "report" usebundle => _logger("Ensure line(s) '${lines}' absent from ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report" usebundle => _log("Ensure line(s) '${lines}' absent from ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_ensure_lines_present.cf
+++ b/tree/30_generic_methods/file_ensure_lines_present.cf
@@ -36,5 +36,5 @@ bundle agent file_ensure_lines_present(file, lines)
       "enforce lines content" usebundle => file_enforce_content("${file}", "${lines}", "false");
       "new result classes"    usebundle => _classes_copy("${class_prefix}_enforce_lines_content", "${class_prefix}");
 
-      "report"                usebundle => _logger("Insert content ${lines} into ${file}", "", "${class_prefix}", @{args});
+      "report"                usebundle => _log("Insert content ${lines} into ${file}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_from_template.cf
+++ b/tree/30_generic_methods/file_from_template.cf
@@ -52,6 +52,6 @@ bundle agent file_from_template(source_template, destination)
       "template_absent" usebundle => _classes_failure("${class_prefix}");
 
     any::
-      "report"          usebundle => _logger("Build file ${destination} from template ${source_template}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"          usebundle => _log("Build file ${destination} from template ${source_template}", "${old_class_prefix}", "${class_prefix}", @{args});
 
 }

--- a/tree/30_generic_methods/file_from_template_mustache.cf
+++ b/tree/30_generic_methods/file_from_template_mustache.cf
@@ -37,5 +37,5 @@ bundle agent file_from_template_mustache(source_template, destination)
     "file template mustache type"  usebundle => file_from_template_type("${source_template}", "${destination}", "mustache");
     "new result classes"           usebundle => _classes_copy("${class_prefix}_file_template_mustache_type", "${class_prefix}");
 
-    "report"                       usebundle => _logger("Build file ${destination} from template ${source_template}", "", "${class_prefix}", @{args});
+    "report"                       usebundle => _log("Build file ${destination} from template ${source_template}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_from_template_type.cf
+++ b/tree/30_generic_methods/file_from_template_type.cf
@@ -54,6 +54,6 @@ bundle agent file_from_template_type(source_template, destination, template_type
       "template_absent" usebundle => _classes_failure("${class_prefix}");
 
     any::
-      "report"          usebundle => _logger("Build file ${destination} from ${template_type} template ${source_template}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"          usebundle => _log("Build file ${destination} from ${template_type} template ${source_template}", "${old_class_prefix}", "${class_prefix}", @{args});
 
 }

--- a/tree/30_generic_methods/file_remove.cf
+++ b/tree/30_generic_methods/file_remove.cf
@@ -44,6 +44,6 @@ bundle agent file_remove(target)
     "success_if_nothing" usebundle => _classes_success("${class_prefix}"),
                          ifvarclass => "has_promiser_stack.!${class_prefix}_reached";
 
-    "report"             usebundle => _logger("Remove file ${target}", "${old_class_prefix}", "${class_prefix}", @{args});
+    "report"             usebundle => _log("Remove file ${target}", "${old_class_prefix}", "${class_prefix}", @{args});
 
 }

--- a/tree/30_generic_methods/file_replace_lines.cf
+++ b/tree/30_generic_methods/file_replace_lines.cf
@@ -43,5 +43,5 @@ bundle agent file_replace_lines(file, line, replacement)
         classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
   methods:
-      "report" usebundle => _logger("Replace line ${lines} with ${replacement} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report" usebundle => _log("Replace line ${lines} with ${replacement} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_template_expand.cf
+++ b/tree/30_generic_methods/file_template_expand.cf
@@ -47,5 +47,5 @@ bundle agent file_template_expand(tml_file, target_file, mode, owner, group)
         classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
   methods:
-      "report"             usebundle => _logger("Expand template ${tml_file} into ${target_file} with perms ${mode}, ${owner}, ${group}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"             usebundle => _log("Expand template ${tml_file} into ${target_file} with perms ${mode}, ${owner}, ${group}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/http_request_check_status_headers.cf
+++ b/tree/30_generic_methods/http_request_check_status_headers.cf
@@ -42,7 +42,7 @@ bundle agent http_request_check_status_headers(method, url, expected_status, hea
 
   methods:
     pass2::
-      "report" usebundle => _logger("Performing a HTTP ${method} request on ${url}, expecting status ${expected_status}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report" usebundle => _log("Performing a HTTP ${method} request on ${url}, expecting status ${expected_status}", "${old_class_prefix}", "${class_prefix}", @{args});
 
   commands:
       "${paths.path[curl]}"

--- a/tree/30_generic_methods/http_request_content_headers.cf
+++ b/tree/30_generic_methods/http_request_content_headers.cf
@@ -42,7 +42,7 @@ bundle agent http_request_content_headers(method, url, content, headers)
 
   methods:
     pass2::
-      "report" usebundle => _logger("Performing a HTTP ${method} request on ${url} with specific content", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report" usebundle => _log("Performing a HTTP ${method} request on ${url} with specific content", "${old_class_prefix}", "${class_prefix}", @{args});
 
   commands:
       "/bin/echo \"${content}\" | ${paths.path[curl]}"

--- a/tree/30_generic_methods/log_rudder.cf
+++ b/tree/30_generic_methods/log_rudder.cf
@@ -1,5 +1,5 @@
 #####################################################################################
-# Copyright 2013 Normation SAS
+# Copyright 2015 Normation SAS
 #####################################################################################
 #
 # This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
 #
 #####################################################################################
 
-# @name Logger for Rudder
+# @name Log for Rudder
 # @description Logging output for Rudder reports
 #
 # @parameter message              The common part of the message to display
@@ -29,7 +29,7 @@
 # The three states are kept, repaired and not_ok
 # (as defined in the classes_generic of the cfengine_stdlib)
 
-bundle agent logger_rudder(message, old_class_prefix, origin_class_prefix, args)
+bundle agent log_rudder(message, old_class_prefix, origin_class_prefix, args)
 {
   vars:
 
@@ -72,8 +72,11 @@ bundle agent logger_rudder(message, old_class_prefix, origin_class_prefix, args)
       #    The previous version of ncf always put "method_call" as a promiser, so this indicates an old technique version
       "method_v2"                  not => strcmp("method_call", nth("this.callers_promisers", "1"));
 
-      # 4/ we aggregate this with the availability of the promiser stack to know if we should report using v2 format
-      "report_v2"           expression => "expected_report_v2_csv.expected_report_v2_res.method_v2.has_promiser_stack";
+      # 4/ We check that the new class_prefix is not empty, otherwise the v2 method would break
+      "class_prefix_v2"            not => strcmp("${origin_class_prefix}", "");
+
+      # 5/ we aggregate this with the availability of the promiser stack to know if we should report using v2 format
+      "report_v2"           expression => "expected_report_v2_csv.expected_report_v2_res.method_v2.has_promiser_stack.class_prefix_v2";
 
       "keys_defined"        expression => isvariable("keys");
 
@@ -114,26 +117,32 @@ bundle agent logger_rudder(message, old_class_prefix, origin_class_prefix, args)
 
     # We HAVE the data and we CAN dot it (see /4 abvove) -> New reporting method
     report_v2::
-      "any" usebundle => _logger_rudder_v2("${expected_reports_source}", "${message}", "${origin_class_prefix}", @{args});
+      "call _log_rudder_v2" usebundle => _log_rudder_v2("${expected_reports_source}", "${message}", "${origin_class_prefix}", @{args});
 }
 
 # Bundle that is called only if we have v2 expected report and the promiser stack
 #
 # It produces new style reports
-# It will completly override logger_rudder when we remove v1 
+# It will completly override log_rudder when we remove v1 
 # Since it uses a new logic and need to parse the original file directly it can be put appart to avoid messing with the original code
 #
 # There is one case it can conflict with the orignal one :
 #  - the expected report contains one line with a v2 style technique that matches current call
 #  - the expected report contains one line with an unrelated v1 style technique that matches the current call too
 # The answer is that you should re-run rudderify on all your techniques when you upgrade
-bundle agent _logger_rudder_v2(expected_reports_source, message, class_prefix, args)
+bundle agent _log_rudder_v2(expected_reports_source, message, class_prefix, args)
 {
   vars:
-      # head(length-3) -> remove logger call stack (_logger + logger_rudder + _logger_rudder)
-      "promiser_count"  int => length("this.callers_promisers");
-      "nologger_len" string => eval("${promiser_count}-3", "math", "infix");
-      "promiser_list_nologger" slist => sublist("this.callers_promisers", "head", "${nologger_len}");
+      # We need to remove the final few promisers from the list of callers_promisers
+      # log call stack (_log + log_rudder + _log_rudder_v2 or _logger + _log + log_rudder + _log_rudder_v2 or logger_rudder + log_rudder + _log_rudder_v2)
+      # 1/ We search for known promisers from _log, _logger, logger_rudder, log_rudder, log_rudder_v2 and remove them
+      "promisers_list"            slist => { @{this.callers_promisers} };
+      "promiser_list_nologgerint" slist => filter("(wrapper for logger_rudder|wrapper for log_rudder|legacy _logger wrapper|legacy logger_rudder wrapper|call _log_rudder_v2)", promisers_list, "true", "true", 9999);
+
+      # 2/ We remove the last promiser, which is the original call to any of the above logger methods
+      "promiser_count"  int => length("this.promiser_list_nologgerint");
+      "nologger_len" string => eval("${promiser_count}-1", "math", "infix");
+      "promiser_list_nologger" slist => sublist("this.promiser_list_nologgerint", "head", "${nologger_len}");
 
       "promisers"    string => join(" / ", "promiser_list_nologger");
 

--- a/tree/30_generic_methods/log_rudder.cf
+++ b/tree/30_generic_methods/log_rudder.cf
@@ -136,17 +136,18 @@ bundle agent _log_rudder_v2(expected_reports_source, message, class_prefix, args
       # We need to remove the final few promisers from the list of callers_promisers
       # log call stack (_log + log_rudder + _log_rudder_v2 or _logger + _log + log_rudder + _log_rudder_v2 or logger_rudder + log_rudder + _log_rudder_v2)
       # 1/ We search for known promisers from _log, _logger, logger_rudder, log_rudder, log_rudder_v2 and remove them
-      "promisers_list"            slist => { @{this.callers_promisers} };
-      "promiser_list_nologgerint" slist => filter("(wrapper for logger_rudder|wrapper for log_rudder|legacy _logger wrapper|legacy logger_rudder wrapper|call _log_rudder_v2)", promisers_list, "true", "true", 9999);
+      "promiser_list"             slist => { @{this.callers_promisers} };
+      "promiser_list_nologgerint" slist => filter("(wrapper for logger_rudder|wrapper for log_rudder|legacy _logger wrapper|legacy logger_rudder wrapper|call _log_rudder_v2)", promiser_list, "true", "true", 999);
 
       # 2/ We remove the last promiser, which is the original call to any of the above logger methods
-      "promiser_count"  int => length("this.promiser_list_nologgerint");
-      "nologger_len" string => eval("${promiser_count}-1", "math", "infix");
-      "promiser_list_nologger" slist => sublist("this.promiser_list_nologgerint", "head", "${nologger_len}");
+      "promiser_count"   int => length("promiser_list_nologgerint");
+      "nologger_len"  string => eval("${promiser_count}-1", "math", "infix");
+      "nologger_len_int" int => "${nologger_len}";
+      "promiser_list_nologger" slist => sublist("promiser_list_nologgerint", "head", "${nologger_len_int}");
 
-      "promisers"    string => join(" / ", "promiser_list_nologger");
+      "promisers"     string => join(" / ", "promiser_list_nologger");
 
-      "number_lines"    int => getfields("^${current_technique_report_info.technique_name};;.*?;;.*?;;.*?;;.*?;;${class_prefix}", 
+      "number_lines"     int => getfields("^${current_technique_report_info.technique_name};;.*?;;.*?;;.*?;;.*?;;${class_prefix}", 
                                          "${expected_reports_source}", 
                                          ";;", 
                                          "report_data");

--- a/tree/30_generic_methods/logger_rudder.cf
+++ b/tree/30_generic_methods/logger_rudder.cf
@@ -1,0 +1,40 @@
+#####################################################################################
+# Copyright 2015 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name Logger for Rudder - legacy interface (DEPRECATED)
+# @description Logging output for Rudder reports. This interface is for compatiblity with older generic methods and techniques, and is replaced by log_rudder.
+#
+# @parameter message              The common part of the message to display
+# @parameter old_class_prefix     The prefix of the class for different states (0.x version, empty to force new style logging only)
+#
+# @class_prefix    logger_rudder
+# @class_parameter old_class_prefix
+# The three states are kept, repaired and not_ok
+# (as defined in the classes_generic of the cfengine_stdlib)
+
+bundle agent logger_rudder(message, old_class_prefix)
+{
+
+  methods:
+      "legacy logger_rudder wrapper" usebundle => log_rudder("${message}", "${old_class_prefix}", "", "");
+
+  reports:
+    cfengine::
+      "WARNING: DEPRECATED logger_rudder interface called. Please use log_rudder instead (${old_class_prefix}: ${message})";
+
+}

--- a/tree/30_generic_methods/logger_rudder.cf
+++ b/tree/30_generic_methods/logger_rudder.cf
@@ -30,8 +30,11 @@
 bundle agent logger_rudder(message, old_class_prefix)
 {
 
+  vars:
+      "empty_slist" slist => { cf_null };
+
   methods:
-      "legacy logger_rudder wrapper" usebundle => log_rudder("${message}", "${old_class_prefix}", "", "");
+      "legacy logger_rudder wrapper" usebundle => log_rudder("${message}", "${old_class_prefix}", "", @{empty_slist});
 
   reports:
     cfengine::

--- a/tree/30_generic_methods/package_check_installed.cf
+++ b/tree/30_generic_methods/package_check_installed.cf
@@ -57,5 +57,5 @@ bundle agent package_check_installed(package_name)
         ifvarclass => "${class_prefix}_check_install_with_latest_version_repaired";
 
       "report"
-        usebundle  => _logger("Check that package ${package_name} is installed", "${old_class_prefix}", "${class_prefix}", @{args});
+        usebundle  => _log("Check that package ${package_name} is installed", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/package_install.cf
+++ b/tree/30_generic_methods/package_install.cf
@@ -35,5 +35,5 @@ bundle agent package_install(package_name)
       "install latest"     usebundle => package_install_version("${package_name}", "latest");
       "new result classes" usebundle => _classes_copy("${class_prefix}_install_latest", "${class_prefix}");
 
-      "report"             usebundle => _logger("Install package ${package_name}", "", "${class_prefix}", @{args});
+      "report"             usebundle => _log("Install package ${package_name}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/package_install_version.cf
+++ b/tree/30_generic_methods/package_install_version.cf
@@ -36,6 +36,6 @@ bundle agent package_install_version(package_name, package_version)
       "install vith version"  usebundle => package_install_version_cmp("${package_name}", "==", "${package_version}", "add");
       "new result classes"    usebundle => _classes_copy("${class_prefix}_install_vith_version", "${class_prefix}");
 
-      "report"                usebundle => _logger("Install package ${package_name} version ${package_version}", "", "${class_prefix}", @{args});
+      "report"                usebundle => _log("Install package ${package_name} version ${package_version}", "", "${class_prefix}", @{args});
 }
 

--- a/tree/30_generic_methods/package_install_version_cmp.cf
+++ b/tree/30_generic_methods/package_install_version_cmp.cf
@@ -42,5 +42,5 @@ bundle agent package_install_version_cmp(package_name, version_comparator, packa
       "install or update"  usebundle => package_install_version_cmp_update("${package_name}", "${version_comparator}", "${package_version}", "${action}", "true");
       "new result classes" usebundle => _classes_copy("${class_prefix}_install_or_update", "${class_prefix}");
 
-      "report"             usebundle => _logger("Install package ${package_name} version ${package_version}", "", "${class_prefix}", @{args});
+      "report"             usebundle => _log("Install package ${package_name} version ${package_version}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/package_install_version_cmp_update.cf
+++ b/tree/30_generic_methods/package_install_version_cmp_update.cf
@@ -164,13 +164,13 @@ bundle agent package_install_version_cmp_update(package_name, version_comparator
 
   methods:
     immediate.!update::
-      "Reports" usebundle => _logger("Install package ${package_name}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "Reports" usebundle => _log("Install package ${package_name}", "${old_class_prefix}", "${class_prefix}", @{args});
     immediate.update::
-      "Reports" usebundle => _logger("Install or update package ${package_name} in version ${package_version}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "Reports" usebundle => _log("Install or update package ${package_name} in version ${package_version}", "${old_class_prefix}", "${class_prefix}", @{args});
     !immediate.!version_not_specified::
-      "Reports" usebundle => _logger("Verify that package ${package_name} is installed in version ${package_version}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "Reports" usebundle => _log("Verify that package ${package_name} is installed in version ${package_version}", "${old_class_prefix}", "${class_prefix}", @{args});
     !immediate.version_not_specified.update::
-      "Reports" usebundle => _logger("Verify that package ${package_name} is installed and up-to-date", "${old_class_prefix}", "${class_prefix}", @{args});
+      "Reports" usebundle => _log("Verify that package ${package_name} is installed and up-to-date", "${old_class_prefix}", "${class_prefix}", @{args});
     !immediate.version_not_specified.!update::
-      "Reports" usebundle => _logger("Verify that package ${package_name} is installed", "${old_class_prefix}", "${class_prefix}", @{args});
+      "Reports" usebundle => _log("Verify that package ${package_name} is installed", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/package_remove.cf
+++ b/tree/30_generic_methods/package_remove.cf
@@ -45,5 +45,5 @@ bundle agent package_remove(package_name)
                         classes         => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
   methods:
-      "placeholder"        usebundle => _logger("Remove package ${package_name}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "placeholder"        usebundle => _log("Remove package ${package_name}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/package_verify.cf
+++ b/tree/30_generic_methods/package_verify.cf
@@ -35,6 +35,6 @@ bundle agent package_verify(package_name)
       "verify latest"      usebundle => package_verify_version("${package_name}", "latest");
       "new result classes" usebundle => _classes_copy("${class_prefix}_verify_latest", "${class_prefix}");
 
-      "report"             usebundle => _logger("Verify that package ${package_name} is installed", "", "${class_prefix}", @{args});
+      "report"             usebundle => _log("Verify that package ${package_name} is installed", "", "${class_prefix}", @{args});
 }
 

--- a/tree/30_generic_methods/package_verify_version.cf
+++ b/tree/30_generic_methods/package_verify_version.cf
@@ -36,5 +36,5 @@ bundle agent package_verify_version(package_name, package_version)
     "package verify"     usebundle => package_install_version_cmp("${package_name}", "==", "${package_version}", "verify");
     "new result classes" usebundle => _classes_copy("${class_prefix}_package_verify", "${class_prefix}");
 
-    "report"             usebundle => _logger("Verify that package ${package_name} is installed in version ${package_version}", "", "${class_prefix}", @{args});
+    "report"             usebundle => _log("Verify that package ${package_name} is installed in version ${package_version}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/permissions.cf
+++ b/tree/30_generic_methods/permissions.cf
@@ -38,5 +38,5 @@ bundle agent permissions(path, mode, owner, group)
       "permission without recursion"  usebundle => permissions_type_recursion("${path}", "${mode}", "${owner}", "${group}", "all", "0");
       "new result classes"            usebundle => _classes_copy("${class_prefix}_permission_without_recursion", "${class_prefix}");
 
-      "report"                        usebundle => _logger("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path}", "", "${class_prefix}", @{args});
+      "report"                        usebundle => _log("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/permissions_dirs.cf
+++ b/tree/30_generic_methods/permissions_dirs.cf
@@ -38,5 +38,5 @@ bundle agent permissions_dirs(path, mode, owner, group)
       "permission without recursion"  usebundle => permissions_type_recursion("${path}", "${mode}", "${owner}", "${group}", "directories", "0");
       "new result classes"            usebundle => _classes_copy("${class_prefix}_permission_without_recursion", "${class_prefix}");
 
-      "report"                        usebundle => _logger("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path}", "", "${class_prefix}", @{args});
+      "report"                        usebundle => _log("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/permissions_dirs_recurse.cf
+++ b/tree/30_generic_methods/permissions_dirs_recurse.cf
@@ -38,5 +38,5 @@ bundle agent permissions_dirs_recurse(path, mode, owner, group)
       "permission with recursion"  usebundle => permissions_type_recursion("${path}", "${mode}", "${owner}", "${group}", "directories", "inf");
       "new result classes"         usebundle => _classes_copy("${class_prefix}_permission_with_recursion", "${class_prefix}");
 
-      "report"                     usebundle => _logger("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path}", "", "${class_prefix}", @{args});
+      "report"                     usebundle => _log("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/permissions_recurse.cf
+++ b/tree/30_generic_methods/permissions_recurse.cf
@@ -38,5 +38,5 @@ bundle agent permissions_recurse(path, mode, owner, group)
       "permission with recursion"  usebundle => permissions_type_recursion("${path}", "${mode}", "${owner}", "${group}", "all", "inf");
       "new result classes"         usebundle => _classes_copy("${class_prefix}_permission_with_recursion", "${class_prefix}");
 
-      "report"                     usebundle => _logger("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path}", "", "${class_prefix}", @{args});
+      "report"                     usebundle => _log("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/permissions_type_recursion.cf
+++ b/tree/30_generic_methods/permissions_type_recursion.cf
@@ -99,5 +99,5 @@ bundle agent permissions_type_recursion(path, mode, owner, group, type, recursio
         classes      => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
   methods:
-      "report"             usebundle => _logger("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"             usebundle => _log("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/schedule_simple.cf
+++ b/tree/30_generic_methods/schedule_simple.cf
@@ -70,6 +70,6 @@ bundle agent schedule_simple(job_id, agent_periodicity,
       "error"    usebundle => _classes_failure("${class_prefix}"),
                  ifvarclass => "job_${job_id}_error";
 
-      "report"    usebundle => _logger("Scheduling ${job_id}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"    usebundle => _log("Scheduling ${job_id}", "${old_class_prefix}", "${class_prefix}", @{args});
 }
 

--- a/tree/30_generic_methods/schedule_simple_catchup.cf
+++ b/tree/30_generic_methods/schedule_simple_catchup.cf
@@ -59,6 +59,6 @@ bundle agent schedule_simple_catchup(job_id, agent_periodicity,
 
       "new result classes" usebundle => _classes_copy("${class_prefix}_simple_scheduler", "${class_prefix}");
 
-      "report"             usebundle => _logger("Scheduling ${job_id}", "", "${class_prefix}", @{args});
+      "report"             usebundle => _log("Scheduling ${job_id}", "", "${class_prefix}", @{args});
 }
 

--- a/tree/30_generic_methods/schedule_simple_nodups.cf
+++ b/tree/30_generic_methods/schedule_simple_nodups.cf
@@ -59,6 +59,6 @@ bundle agent schedule_simple_nodups(job_id, agent_periodicity,
 
       "new result classes" usebundle => _classes_copy("${class_prefix}_simple_scheduler", "${class_prefix}");
 
-      "report"             usebundle => _logger("Scheduling ${job_id}", "", "${class_prefix}", @{args});
+      "report"             usebundle => _log("Scheduling ${job_id}", "", "${class_prefix}", @{args});
 }
 

--- a/tree/30_generic_methods/schedule_simple_stateless.cf
+++ b/tree/30_generic_methods/schedule_simple_stateless.cf
@@ -59,6 +59,6 @@ bundle agent schedule_simple_stateless(job_id, agent_periodicity,
 
       "new result classes" usebundle => _classes_copy("${class_prefix}_simple_scheduler", "${class_prefix}");
 
-      "report"             usebundle => _logger("Scheduling ${job_id}", "", "${class_prefix}", @{args});
+      "report"             usebundle => _log("Scheduling ${job_id}", "", "${class_prefix}", @{args});
 }
 

--- a/tree/30_generic_methods/service_action.cf
+++ b/tree/30_generic_methods/service_action.cf
@@ -71,14 +71,14 @@ bundle agent service_action(service_name, action)
 
     systemctl_utility_present|service_utility_present|init_d_directory_present|(windows.is_valid_action)::
 
-      "report"                    usebundle => _logger("Run action ${action} on service ${service_name}", "${old_class_prefix}", "${class_prefix}", @{args}),
+      "report"                    usebundle => _log("Run action ${action} on service ${service_name}", "${old_class_prefix}", "${class_prefix}", @{args}),
                                  ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
 
     (!systemctl_utility_present.!service_utility_present.!init_d_directory_present.!windows)|(windows.!is_valid_action)::
 
       "force_failure_class"       usebundle => _classes_failure("${old_class_prefix}");
       "force_failure_class"       usebundle => _classes_failure("${class_prefix}");
-      "report"                    usebundle => _logger("Running ${action} on service ${service_name} is not possible yet on this system", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"                    usebundle => _log("Running ${action} on service ${service_name} is not possible yet on this system", "${old_class_prefix}", "${class_prefix}", @{args});
 
   services:
     # Restart causes the agent to fail, so we must replace it by stop and start

--- a/tree/30_generic_methods/service_check_running.cf
+++ b/tree/30_generic_methods/service_check_running.cf
@@ -36,5 +36,5 @@ bundle agent service_check_running(service_name)
       "check running with ps" usebundle => service_check_running_ps("${service_name}");
       "new result classes"    usebundle => _classes_copy("${class_prefix}_check_running_with_ps", "${class_prefix}");
 
-      "report"                usebundle => _logger("Check if the service ${service_regex} is started using ps", "", "${class_prefix}", @{args});
+      "report"                usebundle => _log("Check if the service ${service_regex} is started using ps", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/service_check_running_ps.cf
+++ b/tree/30_generic_methods/service_check_running_ps.cf
@@ -56,7 +56,7 @@ bundle agent service_check_running_ps(service_regex)
         ifvarclass => "has_promiser_stack.${class_prefix}_checked_not_ok";
 
       "report"
-        usebundle  => _logger("Check if the service ${service_regex} is started using ps", "${old_class_prefix}", "${class_prefix}", @{args});
+        usebundle  => _log("Check if the service ${service_regex} is started using ps", "${old_class_prefix}", "${class_prefix}", @{args});
 
   processes:
 

--- a/tree/30_generic_methods/service_check_started_at_boot.cf
+++ b/tree/30_generic_methods/service_check_started_at_boot.cf
@@ -77,5 +77,5 @@ bundle agent service_check_started_at_boot(service_name)
       "failure" usebundle => _classes_failure("${class_prefix}"),
         ifvarclass => "${class_prefix}_check_run_failed";
 
-      "reports" usebundle => _logger("Ensure that service ${service_name} is defined at boot", "${old_class_prefix}", "${class_prefix}", @{args});
+      "reports" usebundle => _log("Ensure that service ${service_name} is defined at boot", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/service_ensure_running.cf
+++ b/tree/30_generic_methods/service_ensure_running.cf
@@ -35,5 +35,5 @@ bundle agent service_ensure_running(service_name)
     "check running"      usebundle => service_ensure_running_path("${service_name}", "${service_name}");
     "new result classes" usebundle => _classes_copy("${class_prefix}_check-running", "${class_prefix}");
 
-    "report"             usebundle => _logger("Ensure that service ${service_name} is running", "", "${class_prefix}", @{args});
+    "report"             usebundle => _log("Ensure that service ${service_name} is running", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/service_ensure_running_path.cf
+++ b/tree/30_generic_methods/service_ensure_running_path.cf
@@ -65,7 +65,7 @@ bundle agent service_ensure_running_path(service_name, service_path)
 
     any::
       "report"
-        usebundle  => _logger("Ensure that service ${service_name} is running", "${old_class_prefix}", "${class_prefix}", @{args}),
+        usebundle  => _log("Ensure that service ${service_name} is running", "${old_class_prefix}", "${class_prefix}", @{args}),
         ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
 
   services:

--- a/tree/30_generic_methods/service_ensure_started_at_boot.cf
+++ b/tree/30_generic_methods/service_ensure_started_at_boot.cf
@@ -73,7 +73,7 @@ bundle agent service_ensure_started_at_boot(service_name)
 
    any::
       "report"
-        usebundle => _logger("Ensure service ${service_name} is set at boot", "${old_class_prefix}", "${class_prefix}", @{args}),
+        usebundle => _log("Ensure service ${service_name} is set at boot", "${old_class_prefix}", "${class_prefix}", @{args}),
         ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
 
   services:

--- a/tree/30_generic_methods/service_ensure_stopped.cf
+++ b/tree/30_generic_methods/service_ensure_stopped.cf
@@ -64,7 +64,7 @@ bundle agent service_ensure_stopped(service_name)
 
     any::
       "report"
-        usebundle  => _logger("Ensure that service ${service_name} is stopped", "${old_class_prefix}", "${class_prefix}", @{args}),
+        usebundle  => _log("Ensure that service ${service_name} is stopped", "${old_class_prefix}", "${class_prefix}", @{args}),
         ifvarclass =>"(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.!${class_prefix}_reached)";
 
   services:

--- a/tree/30_generic_methods/service_reload.cf
+++ b/tree/30_generic_methods/service_reload.cf
@@ -43,5 +43,5 @@ bundle agent service_reload(service_name)
 
     "class copy" usebundle => _classes_copy("${class_prefix}_reload", "${class_prefix}");
 
-    "report"     usebundle => _logger("Reload service ${service_name}", "${old_class_prefix}", "${class_prefix}", @{args});
+    "report"     usebundle => _log("Reload service ${service_name}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/service_restart.cf
+++ b/tree/30_generic_methods/service_restart.cf
@@ -36,5 +36,5 @@ bundle agent service_restart(service_name)
 
       "new result classes" usebundle => _classes_copy("${class_prefix}_restart_always", "${class_prefix}");
 
-      "report"             usebundle => _logger("Restart service ${canonified_service_name}", "", "${class_prefix}", @{args});
+      "report"             usebundle => _log("Restart service ${canonified_service_name}", "", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/service_restart_if.cf
+++ b/tree/30_generic_methods/service_restart_if.cf
@@ -57,5 +57,5 @@ bundle agent service_restart_if(service_name, trigger_class)
       "class copy"                 usebundle  => _classes_copy("${class_prefix}_restart", "${class_prefix}"),
                                    ifvarclass => "${trigger_class}";
 
-      "report"                     usebundle  => _logger("Restart service ${canonified_service_name}", "service_restart_${canonified_service_name}", "${class_prefix}", @{args});
+      "report"                     usebundle  => _log("Restart service ${canonified_service_name}", "service_restart_${canonified_service_name}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/service_start.cf
+++ b/tree/30_generic_methods/service_start.cf
@@ -43,6 +43,6 @@ bundle agent service_start(service_name)
 
     "class copy" usebundle => _classes_copy("${class_prefix}_start", "${class_prefix}");
 
-    "report"     usebundle => _logger("Start service ${service_name}", "${old_class_prefix}", "${class_prefix}", @{args});
+    "report"     usebundle => _log("Start service ${service_name}", "${old_class_prefix}", "${class_prefix}", @{args});
 
 }

--- a/tree/30_generic_methods/service_stop.cf
+++ b/tree/30_generic_methods/service_stop.cf
@@ -43,6 +43,6 @@ bundle agent service_stop(service_name)
 
     "class copy" usebundle => _classes_copy("${class_prefix}_stop", "${class_prefix}");
 
-    "report"     usebundle => _logger("Stop service ${service_name}", "${old_class_prefix}", "${class_prefix}", @{args});
+    "report"     usebundle => _log("Stop service ${service_name}", "${old_class_prefix}", "${class_prefix}", @{args});
 
 }

--- a/tree/30_generic_methods/variable_dict.cf
+++ b/tree/30_generic_methods/variable_dict.cf
@@ -61,5 +61,5 @@ bundle agent variable_dict(variable_prefix, variable_name, value)
 
     any::
       "report"
-        usebundle  => _logger("Set the dict ${variable_prefix}.${variable_name} to ${value}", "${old_class_prefix}", "${class_prefix}", @{args});
+        usebundle  => _log("Set the dict ${variable_prefix}.${variable_name} to ${value}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/variable_dict_from_file.cf
+++ b/tree/30_generic_methods/variable_dict_from_file.cf
@@ -60,7 +60,7 @@ bundle agent variable_dict_from_file(variable_prefix, variable_name, file_name)
 
     any::
       "report"
-        usebundle  => _logger("Set the dict ${variable_prefix}.${variable_name} to the content of ${file_name}", "${old_class_prefix}", "${class_prefix}", @{args});
+        usebundle  => _log("Set the dict ${variable_prefix}.${variable_name} to the content of ${file_name}", "${old_class_prefix}", "${class_prefix}", @{args});
   reports:
     "${file_name} -> ${${variable_prefix}.${variable_name}}";
 }

--- a/tree/30_generic_methods/variable_iterator.cf
+++ b/tree/30_generic_methods/variable_iterator.cf
@@ -66,5 +66,5 @@ bundle agent variable_iterator(variable_prefix, variable_name, value, separator)
 
     any::
       "report"
-        usebundle  => _logger("Set the iterator ${variable_prefix}.${variable_name} value to ${value}", "${old_class_prefix}", "${class_prefix}", @{args});
+        usebundle  => _log("Set the iterator ${variable_prefix}.${variable_name} value to ${value}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/variable_iterator_from_file.cf
+++ b/tree/30_generic_methods/variable_iterator_from_file.cf
@@ -68,5 +68,5 @@ bundle agent variable_iterator_from_file(variable_prefix, variable_name, file_na
 
     any::
       "report"
-        usebundle  => _logger("Set the iterator ${variable_prefix}.${variable_name} value to ${file_name} content", "${old_class_prefix}", "${class_prefix}", @{args});
+        usebundle  => _log("Set the iterator ${variable_prefix}.${variable_name} value to ${file_name} content", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/variable_string.cf
+++ b/tree/30_generic_methods/variable_string.cf
@@ -60,5 +60,5 @@ bundle agent variable_string(variable_prefix, variable_name, value)
 
     any::
       "report"
-        usebundle  => _logger("Set the string ${variable_prefix}.${variable_name} to value ${value}", "${old_class_prefix}", "${class_prefix}", @{args});
+        usebundle  => _log("Set the string ${variable_prefix}.${variable_name} to value ${value}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/variable_string_from_file.cf
+++ b/tree/30_generic_methods/variable_string_from_file.cf
@@ -61,5 +61,5 @@ bundle agent variable_string_from_file(variable_prefix, variable_name, file_name
 
     any::
       "report"
-        usebundle  => _logger("Set the string ${variable_prefix}.${variable_name} to the content of ${file_name}", "${old_class_prefix}", "${class_prefix}", @{args});
+        usebundle  => _log("Set the string ${variable_prefix}.${variable_name} to the content of ${file_name}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/ncf.conf
+++ b/tree/ncf.conf
@@ -11,7 +11,7 @@
 #
 {{#classes.any}}
 # Which logger(s) should be used in ncf? (comma separated list)
-loggers=_logger_default
+loggers=_log_default
 # Which port should be for CFEngine connections/data transfers
 cfengine_port=5308
 {{/classes.any}}


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7436