### PR TITLE
Fixes #7459: Reporting is broken for several ncf generic methods because the new class_prefix is not computer without this.callers_promisers, and any conditions using class_prefix are incorrectly evaluated

### DIFF
--- a/tests/style/30_generic_methods/all_generic_methods_should_use_intermediary_promisers_slist.sh
+++ b/tests/style/30_generic_methods/all_generic_methods_should_use_intermediary_promisers_slist.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+#####################################################################################
+# Copyright 2015 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+set -e
+
+# Check that all generic_methods use a classes => classes_generic_two body and not the plain classes_generic
+# This is necessary for the transition from old to new reporting style, based on multiple class names
+
+FILES_TO_CHECK=`find "${NCF_TREE}/30_generic_methods/" -name "*.cf"`
+NB_ERROR=0
+for f in ${FILES_TO_CHECK}
+do
+
+  NB_BUNDLE=$(egrep '^[^#]*"class_prefix"\s+string\s*=>.*this.callers_promisers' $f | wc -l)
+  if [ $NB_BUNDLE -ne 0 ]; then
+    echo "File $f uses old class_prefix style line, instead of intermediary slist - see http://www.rudder-project.org/redmine/issues/7459"
+    NB_ERROR=`expr $NB_ERROR + 1`
+  fi
+done
+
+if [ $NB_ERROR -eq 0 ]; then
+  echo "R: $0 Pass"
+else
+  echo "R: $0 Fail"
+fi
+
+exit $NB_ERROR

--- a/tree/30_generic_methods/command_execution.cf
+++ b/tree/30_generic_methods/command_execution.cf
@@ -29,7 +29,8 @@ bundle agent command_execution(command_name)
 {
   vars:
       "old_class_prefix"  string => canonify("command_execution_${command_name}");
-      "class_prefix"      string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${command_name}" };
 
   methods:

--- a/tree/30_generic_methods/command_execution_result.cf
+++ b/tree/30_generic_methods/command_execution_result.cf
@@ -35,7 +35,8 @@ bundle agent command_execution_result(command, kept_codes, repaired_codes)
 {
   vars:
       "old_class_prefix"  string => canonify("command_execution_result_${command}");
-      "class_prefix"      string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${command}", "${kept_codes}", "${repaired_codes}" };
 
       "kept_list"     slist => splitstring("${kept_codes}", "\s*,\s*", "256");

--- a/tree/30_generic_methods/condition_from_command.cf
+++ b/tree/30_generic_methods/condition_from_command.cf
@@ -42,7 +42,8 @@ bundle agent condition_from_command(condition_prefix, command, true_codes, false
 {
   vars:
       "old_class_prefix"  string => canonify("condition_from_command_${condition_prefix}");
-      "class_prefix"      string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${condition_prefix}", "${command}", "${true_codes}", "${false_codes}" };
 
       "true_list"     slist => splitstring("${true_codes}", "\s*,\s*", "256");

--- a/tree/30_generic_methods/condition_from_expression.cf
+++ b/tree/30_generic_methods/condition_from_expression.cf
@@ -39,7 +39,8 @@ bundle agent condition_from_expression(condition_prefix, condition_expression)
 {
   vars:
       "old_class_prefix"  string => canonify("condition_from_expression_${condition_prefix}");
-      "class_prefix"      string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${condition_prefix}", "${condition_expression}" };
 
   classes:

--- a/tree/30_generic_methods/condition_from_expression_persistent.cf
+++ b/tree/30_generic_methods/condition_from_expression_persistent.cf
@@ -39,7 +39,8 @@ bundle agent condition_from_expression_persistent(condition_prefix, condition_ex
 {
   vars:
       "old_class_prefix"  string => canonify("condition_from_expression_persistent_${condition_prefix}");
-      "class_prefix"      string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${condition_prefix}", "${condition_expression}", "${duration}" };
 
   classes:

--- a/tree/30_generic_methods/directory_check_exists.cf
+++ b/tree/30_generic_methods/directory_check_exists.cf
@@ -31,7 +31,8 @@ bundle agent directory_check_exists(directory_name)
 {
   vars:
       "old_class_prefix" string => canonify("directory_check_exists_${directory_name}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${directory_name}" };
 
   classes:

--- a/tree/30_generic_methods/directory_create.cf
+++ b/tree/30_generic_methods/directory_create.cf
@@ -29,7 +29,8 @@ bundle agent directory_create(target)
 {
   vars:
     "old_class_prefix" string => canonify("directory_create_${target}");
-    "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"              slist => { "${target}" };
 
   files:

--- a/tree/30_generic_methods/file_check_exists.cf
+++ b/tree/30_generic_methods/file_check_exists.cf
@@ -31,7 +31,8 @@ bundle agent file_check_exists(file_name)
 {
   vars:
       "old_class_prefix" string => canonify("file_check_exists_${file_name}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${file_name}" };
 
   classes:

--- a/tree/30_generic_methods/file_copy_from_local_source.cf
+++ b/tree/30_generic_methods/file_copy_from_local_source.cf
@@ -29,7 +29,8 @@
 bundle agent file_copy_from_local_source(source, destination)
 {
   vars:
-     "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+     "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+     "class_prefix"      string => canonify(join("_", "promisers"));
       "args"             slist => { "${source}", "${destination}" };
 
   methods:

--- a/tree/30_generic_methods/file_copy_from_local_source_recursion.cf
+++ b/tree/30_generic_methods/file_copy_from_local_source_recursion.cf
@@ -31,7 +31,8 @@ bundle agent file_copy_from_local_source_recursion(source, destination, recursio
 {
   vars:
       "old_class_prefix" string => canonify("file_copy_from_local_source_${destination}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${source}", "${destination}", "${recursion}" };
 
   classes:

--- a/tree/30_generic_methods/file_copy_from_remote_source.cf
+++ b/tree/30_generic_methods/file_copy_from_remote_source.cf
@@ -29,7 +29,8 @@
 bundle agent file_copy_from_remote_source(source, destination)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${source}", "${destination}" };
 
   methods:

--- a/tree/30_generic_methods/file_copy_from_remote_source_recursion.cf
+++ b/tree/30_generic_methods/file_copy_from_remote_source_recursion.cf
@@ -31,7 +31,8 @@ bundle agent file_copy_from_remote_source_recursion(source, destination, recursi
 {
   vars:
       "old_class_prefix" string => canonify("file_copy_from_remote_source_${destination}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${source}", "${destination}", "${recursion}" };
 
   classes:

--- a/tree/30_generic_methods/file_create.cf
+++ b/tree/30_generic_methods/file_create.cf
@@ -29,7 +29,8 @@ bundle agent file_create(target)
 {
   vars:
     "old_class_prefix" string => canonify("file_create_${target}");
-    "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"              slist => { "${target}" };
 
   files:

--- a/tree/30_generic_methods/file_create_symlink.cf
+++ b/tree/30_generic_methods/file_create_symlink.cf
@@ -29,7 +29,8 @@
 bundle agent file_create_symlink(source, destination)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${source}", "${destination}" };
 
   methods:

--- a/tree/30_generic_methods/file_create_symlink_enforce.cf
+++ b/tree/30_generic_methods/file_create_symlink_enforce.cf
@@ -31,7 +31,8 @@ bundle agent file_create_symlink_enforce(source, destination, enforce)
 {
   vars:
       "old_class_prefix" string => canonify("file_create_symlink_${destination}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${source}", "${destination}", "${enforce}" };
 
   files:

--- a/tree/30_generic_methods/file_create_symlink_force.cf
+++ b/tree/30_generic_methods/file_create_symlink_force.cf
@@ -29,7 +29,8 @@
 bundle agent file_create_symlink_force(source, destination)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${source}", "${destination}" };
 
   methods:

--- a/tree/30_generic_methods/file_download.cf
+++ b/tree/30_generic_methods/file_download.cf
@@ -45,7 +45,8 @@ bundle agent file_download(source, destination)
       "canonified_action_command" string => canonify("${action_command}");
 
       "old_class_prefix"          string => "file_download_${canonified_destination}";
-      "class_prefix"              string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"                       slist => { "${source}", "${destination}" };
 
   classes:

--- a/tree/30_generic_methods/file_enforce_content.cf
+++ b/tree/30_generic_methods/file_enforce_content.cf
@@ -31,7 +31,8 @@ bundle agent file_enforce_content(file, lines, enforce)
 {
   vars:
       "old_class_prefix" string => canonify("file_ensure_lines_present_${file}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${file}", "${lines}", "${enforce}" };
 
   files:

--- a/tree/30_generic_methods/file_ensure_block_in_section.cf
+++ b/tree/30_generic_methods/file_ensure_block_in_section.cf
@@ -32,7 +32,8 @@ bundle agent file_ensure_block_in_section(file, section_start, section_end, bloc
 {
   vars:
       "old_class_prefix" string => canonify("file_ensure_block_in_section_${file}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${file}", "${section_start}", "${section_end}", "${block}" };
 
   files:

--- a/tree/30_generic_methods/file_ensure_block_present.cf
+++ b/tree/30_generic_methods/file_ensure_block_present.cf
@@ -30,7 +30,8 @@ bundle agent file_ensure_block_present(file, block)
 {
   vars:
       "old_class_prefix" string => canonify("file_ensure_block_present_${file}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${file}", "${block}" };
 
   files:

--- a/tree/30_generic_methods/file_ensure_key_value_present_in_ini_section.cf
+++ b/tree/30_generic_methods/file_ensure_key_value_present_in_ini_section.cf
@@ -33,7 +33,8 @@ bundle agent file_ensure_key_value_present_in_ini_section(file, section, name, v
 {
   vars:
       "old_class_prefix" string => canonify("file_ensure_key_value_present_in_ini_section_${file}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${file}", "${section}", "${name}", "${value}" };
 
       "content[${section}][${name}]" string => "${value}";

--- a/tree/30_generic_methods/file_ensure_keys_values.cf
+++ b/tree/30_generic_methods/file_ensure_keys_values.cf
@@ -32,7 +32,8 @@ bundle agent file_ensure_keys_values(file, keys, separator)
 {
   vars:
       "old_class_prefix" string => canonify("file_ensure_keys_values_${file}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${file}", "${keys}", "${separator}" };
 
   files:

--- a/tree/30_generic_methods/file_ensure_line_present_in_ini_section.cf
+++ b/tree/30_generic_methods/file_ensure_line_present_in_ini_section.cf
@@ -32,7 +32,8 @@ bundle agent file_ensure_line_present_in_ini_section(file, section, line)
 {
   vars:
       "old_class_prefix"       string => canonify("file_ensure_line_present_in_ini_section_${file}");
-      "class_prefix"           string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"                    slist => { "${file}", "${section}", "${line}" };
       "section_and_blank_line" string => "[${section}]
 ";

--- a/tree/30_generic_methods/file_ensure_line_present_in_xml_tag.cf
+++ b/tree/30_generic_methods/file_ensure_line_present_in_xml_tag.cf
@@ -32,7 +32,8 @@ bundle agent file_ensure_line_present_in_xml_tag(file, tag, line)
 {
   vars:
       "old_class_prefix" string => canonify("file_ensure_line_present_in_xml_tag_${file}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${file}", "${tag}", "${line}" };
 
   classes:

--- a/tree/30_generic_methods/file_ensure_lines_absent.cf
+++ b/tree/30_generic_methods/file_ensure_lines_absent.cf
@@ -30,7 +30,8 @@ bundle agent file_ensure_lines_absent(file, lines)
 {
   vars:
       "old_class_prefix" string => canonify("file_ensure_lines_absent_${file}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${file}", "${lines}" };
 
   files:

--- a/tree/30_generic_methods/file_ensure_lines_present.cf
+++ b/tree/30_generic_methods/file_ensure_lines_present.cf
@@ -29,7 +29,8 @@
 bundle agent file_ensure_lines_present(file, lines)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${file}", "${lines}" };
 
   methods:

--- a/tree/30_generic_methods/file_from_template.cf
+++ b/tree/30_generic_methods/file_from_template.cf
@@ -30,7 +30,8 @@ bundle agent file_from_template(source_template, destination)
 {
   vars:
     "old_class_prefix" string => canonify("file_from_template_${destination}");
-    "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"              slist => { "${source_template}", "${destination}" };
 
   classes:

--- a/tree/30_generic_methods/file_from_template_mustache.cf
+++ b/tree/30_generic_methods/file_from_template_mustache.cf
@@ -30,7 +30,8 @@
 bundle agent file_from_template_mustache(source_template, destination)
 {
   vars:
-    "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"              slist => { "${source_template}", "${destination}" };
 
   methods:

--- a/tree/30_generic_methods/file_from_template_type.cf
+++ b/tree/30_generic_methods/file_from_template_type.cf
@@ -32,7 +32,8 @@ bundle agent file_from_template_type(source_template, destination, template_type
 {
   vars:
     "old_class_prefix" string => canonify("file_from_template_${destination}");
-    "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"              slist => { "${source_template}", "${destination}", "${template_type}" };
 
   classes:

--- a/tree/30_generic_methods/file_remove.cf
+++ b/tree/30_generic_methods/file_remove.cf
@@ -29,7 +29,8 @@ bundle agent file_remove(target)
 {
   vars:
     "old_class_prefix" string => canonify("file_remove_${target}");
-    "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"              slist => { "${target}" };
 
   files:

--- a/tree/30_generic_methods/file_replace_lines.cf
+++ b/tree/30_generic_methods/file_replace_lines.cf
@@ -32,7 +32,8 @@ bundle agent file_replace_lines(file, line, replacement)
 {
   vars:
       "old_class_prefix" string => canonify("file_replace_lines_${file}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${file}", "${line}", "${replacement}" };
 
   files:

--- a/tree/30_generic_methods/file_template_expand.cf
+++ b/tree/30_generic_methods/file_template_expand.cf
@@ -35,7 +35,8 @@ bundle agent file_template_expand(tml_file, target_file, mode, owner, group)
 {
   vars:
       "old_class_prefix" string => canonify("file_template_expand_${target_file}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${tml_file}", "${target_file}", "${mode}", "${owner}", "${group}" };
 
   files:

--- a/tree/30_generic_methods/http_request_check_status_headers.cf
+++ b/tree/30_generic_methods/http_request_check_status_headers.cf
@@ -32,7 +32,8 @@ bundle agent http_request_check_status_headers(method, url, expected_status, hea
 {
   vars:
       "old_class_prefix" string => canonify("http_request_check_status_headers_${url}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${method}", "${url}", "${expected_status}", "${headers}" };
 
   classes:

--- a/tree/30_generic_methods/http_request_content_headers.cf
+++ b/tree/30_generic_methods/http_request_content_headers.cf
@@ -32,7 +32,8 @@ bundle agent http_request_content_headers(method, url, content, headers)
 {
   vars:
       "old_class_prefix" string => canonify("http_request_content_headers_${url}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${method}", "${url}", "${content}", "${headers}" };
 
   classes:

--- a/tree/30_generic_methods/package_check_installed.cf
+++ b/tree/30_generic_methods/package_check_installed.cf
@@ -32,7 +32,8 @@ bundle agent package_check_installed(package_name)
 {
   vars:
       "old_class_prefix"    string => canonify("package_check_installed_${package_name}");
-      "class_prefix"        string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"                 slist => { "${package_name}" };
       "called_class_prefix" string => canonify("package_install_${package_name}");
 

--- a/tree/30_generic_methods/package_install.cf
+++ b/tree/30_generic_methods/package_install.cf
@@ -28,7 +28,8 @@
 bundle agent package_install(package_name)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${package_name}" };
   
   methods:

--- a/tree/30_generic_methods/package_install_version.cf
+++ b/tree/30_generic_methods/package_install_version.cf
@@ -29,7 +29,8 @@
 bundle agent package_install_version(package_name, package_version)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${package_name}", "${package_version}" };
   
   methods:

--- a/tree/30_generic_methods/package_install_version_cmp.cf
+++ b/tree/30_generic_methods/package_install_version_cmp.cf
@@ -35,7 +35,8 @@
 bundle agent package_install_version_cmp(package_name, version_comparator, package_version, action)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${package_name}", "${version_comparator}", "${package_version}", "${action}" };
 
   methods:

--- a/tree/30_generic_methods/package_install_version_cmp_update.cf
+++ b/tree/30_generic_methods/package_install_version_cmp_update.cf
@@ -38,7 +38,8 @@ bundle agent package_install_version_cmp_update(package_name, version_comparator
   vars:
       "canonified_package_name" string => canonify("${package_name}");
       "old_class_prefix"        string => "package_install_${canonified_package_name}";
-      "class_prefix"            string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"                     slist => { "${package_name}", "${version_comparator}", "${package_version}", "${action}", "${update_policy}" };
 
   defaults:

--- a/tree/30_generic_methods/package_remove.cf
+++ b/tree/30_generic_methods/package_remove.cf
@@ -35,7 +35,8 @@ bundle agent package_remove(package_name)
 
       "canonified_package_name" string => canonify("${package_name}");
       "old_class_prefix"        string => "package_remove_${canonified_package_name}";
-      "class_prefix"            string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"                     slist => { "${package_name}" };
 
   packages:

--- a/tree/30_generic_methods/package_verify.cf
+++ b/tree/30_generic_methods/package_verify.cf
@@ -28,7 +28,8 @@
 bundle agent package_verify(package_name)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${package_name}" };
 
   methods:

--- a/tree/30_generic_methods/package_verify_version.cf
+++ b/tree/30_generic_methods/package_verify_version.cf
@@ -29,7 +29,8 @@
 bundle agent package_verify_version(package_name, package_version)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${package_name}", "${package_name}" };
 
   methods:

--- a/tree/30_generic_methods/permissions.cf
+++ b/tree/30_generic_methods/permissions.cf
@@ -31,7 +31,8 @@
 bundle agent permissions(path, mode, owner, group)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${mode}", "${mode}", "${owner}", "${group}" };
 
   methods:

--- a/tree/30_generic_methods/permissions_dirs.cf
+++ b/tree/30_generic_methods/permissions_dirs.cf
@@ -31,7 +31,8 @@
 bundle agent permissions_dirs(path, mode, owner, group)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${path}", "${mode}", "${owner}", "${group}" };
 
   methods:

--- a/tree/30_generic_methods/permissions_dirs_recurse.cf
+++ b/tree/30_generic_methods/permissions_dirs_recurse.cf
@@ -31,7 +31,8 @@
 bundle agent permissions_dirs_recurse(path, mode, owner, group)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${path}", "${mode}", "${owner}", "${group}" };
 
   methods:

--- a/tree/30_generic_methods/permissions_recurse.cf
+++ b/tree/30_generic_methods/permissions_recurse.cf
@@ -31,7 +31,8 @@
 bundle agent permissions_recurse(path, mode, owner, group)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${path}", "${mode}", "${owner}", "${group}" };
 
   methods:

--- a/tree/30_generic_methods/permissions_type_recursion.cf
+++ b/tree/30_generic_methods/permissions_type_recursion.cf
@@ -34,7 +34,8 @@ bundle agent permissions_type_recursion(path, mode, owner, group, type, recursio
 {
   vars:
       "old_class_prefix"        string => canonify("permissions_${path}");
-      "class_prefix"            string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"                     slist => { "${path}", "${mode}", "${owner}", "${group}", "${type}", "${recursion}" };
 
   classes:

--- a/tree/30_generic_methods/schedule_simple.cf
+++ b/tree/30_generic_methods/schedule_simple.cf
@@ -47,7 +47,8 @@ bundle agent schedule_simple(job_id, agent_periodicity,
   vars:
     any::
       "old_class_prefix" string => "schedule_simple_${job_id}";
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${job_id}", "${agent_periodicity}", "${max_execution_delay_minutes}", "${max_execution_delay_hours}",
                                       "${start_on_minutes}", "${start_on_hours}", "${start_on_day_of_week}",
                                       "${periodicity_minutes}", "${periodicity_hours}", "${periodicity_days}", "${mode}" };

--- a/tree/30_generic_methods/schedule_simple_catchup.cf
+++ b/tree/30_generic_methods/schedule_simple_catchup.cf
@@ -46,7 +46,8 @@ bundle agent schedule_simple_catchup(job_id, agent_periodicity,
 {
   vars:
     any::
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${job_id}", "${agent_periodicity}", "${max_execution_delay_minutes}", "${max_execution_delay_hours}", 
                                       "${start_on_minutes}", "${start_on_hours}", "${start_on_day_of_week}", 
                                       "${periodicity_minutes}", "${periodicity_hours}", "${periodicity_days}" };

--- a/tree/30_generic_methods/schedule_simple_nodups.cf
+++ b/tree/30_generic_methods/schedule_simple_nodups.cf
@@ -46,7 +46,8 @@ bundle agent schedule_simple_nodups(job_id, agent_periodicity,
 {
   vars:
     any::
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${job_id}", "${agent_periodicity}", "${max_execution_delay_minutes}", "${max_execution_delay_hours}",
                                       "${start_on_minutes}", "${start_on_hours}", "${start_on_day_of_week}",
                                       "${periodicity_minutes}", "${periodicity_hours}", "${periodicity_days}" };

--- a/tree/30_generic_methods/schedule_simple_stateless.cf
+++ b/tree/30_generic_methods/schedule_simple_stateless.cf
@@ -46,7 +46,8 @@ bundle agent schedule_simple_stateless(job_id, agent_periodicity,
 {
   vars:
     any::
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${job_id}", "${agent_periodicity}", "${max_execution_delay_minutes}", "${max_execution_delay_hours}",
                                       "${start_on_minutes}", "${start_on_hours}", "${start_on_day_of_week}",
                                       "${periodicity_minutes}", "${periodicity_hours}", "${periodicity_days}" };

--- a/tree/30_generic_methods/service_action.cf
+++ b/tree/30_generic_methods/service_action.cf
@@ -48,7 +48,8 @@ bundle agent service_action(service_name, action)
       "canonified_action_command" string => canonify("${action_command}");
 
       "old_class_prefix"          string => "service_action_${canonified_service_name}";
-      "class_prefix"              string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"                       slist => { "${service_name}", "${action}" };
 
   classes:

--- a/tree/30_generic_methods/service_check_running.cf
+++ b/tree/30_generic_methods/service_check_running.cf
@@ -28,7 +28,8 @@
 bundle agent service_check_running(service_name)
 {
   vars:
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${service_name}" };
 
   methods:

--- a/tree/30_generic_methods/service_check_running_ps.cf
+++ b/tree/30_generic_methods/service_check_running_ps.cf
@@ -29,7 +29,8 @@ bundle agent service_check_running_ps(service_regex)
 {
   vars:
       "old_class_prefix" string => canonify("service_check_running_${service_regex}");
-      "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${service_regex}" };
 
   classes:

--- a/tree/30_generic_methods/service_check_started_at_boot.cf
+++ b/tree/30_generic_methods/service_check_started_at_boot.cf
@@ -44,7 +44,8 @@ bundle agent service_check_started_at_boot(service_name)
       "canonified_command"      string => canonify("${command_to_check}");
 
       "old_class_prefix"        string => "service_check_started_at_boot_${canonified_service_name}";
-      "class_prefix"            string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"                     slist => { "${service_name}" };
 
   classes:

--- a/tree/30_generic_methods/service_ensure_running.cf
+++ b/tree/30_generic_methods/service_ensure_running.cf
@@ -28,7 +28,8 @@
 bundle agent service_ensure_running(service_name)
 {
   vars:
-    "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"              slist => { "${service_name}" };
 
   methods:

--- a/tree/30_generic_methods/service_ensure_running_path.cf
+++ b/tree/30_generic_methods/service_ensure_running_path.cf
@@ -35,7 +35,8 @@ bundle agent service_ensure_running_path(service_name, service_path)
     "canonified_service_path"      string => canonify("${service_path}");
 
     "old_class_prefix"             string => "service_ensure_running_${canonified_service_name}";
-    "class_prefix"                 string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"                          slist => { "${service_name}", "${service_path}" };
 
   methods:

--- a/tree/30_generic_methods/service_ensure_started_at_boot.cf
+++ b/tree/30_generic_methods/service_ensure_started_at_boot.cf
@@ -43,7 +43,8 @@ bundle agent service_ensure_started_at_boot(service_name)
       "canonified_command_name" string => canonify("${command_to_register}");
 
       "old_class_prefix"        string => "service_ensure_started_at_boot_${canonified_service_name}";
-      "class_prefix"            string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"                     slist => { "${service_name}" };
 
   methods:

--- a/tree/30_generic_methods/service_ensure_stopped.cf
+++ b/tree/30_generic_methods/service_ensure_stopped.cf
@@ -32,7 +32,8 @@ bundle agent service_ensure_stopped(service_name)
     "canonified_service_name"      string => canonify("${service_name}");
 
     "old_class_prefix"             string => "service_ensure_stopped_${canonified_service_name}";
-    "class_prefix"                 string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"                          slist => { "${service_name}" };
 
   methods:

--- a/tree/30_generic_methods/service_reload.cf
+++ b/tree/30_generic_methods/service_reload.cf
@@ -32,7 +32,8 @@ bundle agent service_reload(service_name)
     "canonified_service_name" string => canonify("${service_name}");
 
     "old_class_prefix"        string => "service_reload_${canonified_service_name}";
-    "class_prefix"            string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"                    slist => { "${service_name}" };
 
   methods:

--- a/tree/30_generic_methods/service_restart.cf
+++ b/tree/30_generic_methods/service_restart.cf
@@ -28,7 +28,8 @@
 bundle agent service_restart(service_name)
 {
   vars:
-    "class_prefix"     string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"              slist => { "${service_name}" };
 
   methods:

--- a/tree/30_generic_methods/service_restart_if.cf
+++ b/tree/30_generic_methods/service_restart_if.cf
@@ -34,7 +34,8 @@ bundle agent service_restart_if(service_name, trigger_class)
     "canonified_service_name"      string => canonify("${service_name}");
 
     "old_class_prefix"             string => "service_restart_${canonified_service_name}";
-    "class_prefix"                 string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"                          slist => { "${service_name}",  "${trigger_class}" };
 
   methods:

--- a/tree/30_generic_methods/service_start.cf
+++ b/tree/30_generic_methods/service_start.cf
@@ -32,7 +32,8 @@ bundle agent service_start(service_name)
     "canonified_service_name" string => canonify("${service_name}");
 
     "old_class_prefix"        string => "service_start_${canonified_service_name}";
-    "class_prefix"            string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"                     slist => { "${service_name}" };
 
   methods:

--- a/tree/30_generic_methods/service_stop.cf
+++ b/tree/30_generic_methods/service_stop.cf
@@ -32,7 +32,8 @@ bundle agent service_stop(service_name)
     "canonified_service_name" string => canonify("${service_name}");
 
     "old_class_prefix"        string => "service_stop_${canonified_service_name}";
-    "class_prefix"            string => canonify(join("_", "this.callers_promisers"));
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
     "args"                     slist => { "${service_name}" };
 
   methods:

--- a/tree/30_generic_methods/variable_dict.cf
+++ b/tree/30_generic_methods/variable_dict.cf
@@ -41,7 +41,8 @@ bundle agent variable_dict(variable_prefix, variable_name, value)
 {
   vars:
       "old_class_prefix"  string => canonify("variable_dict_${variable_name}");
-      "class_prefix"      string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${variable_prefix}", "${variable_name}", "${value}" };
 
       # define the variable within the class_prefix namespace

--- a/tree/30_generic_methods/variable_dict_from_file.cf
+++ b/tree/30_generic_methods/variable_dict_from_file.cf
@@ -40,7 +40,8 @@ bundle agent variable_dict_from_file(variable_prefix, variable_name, file_name)
 {
   vars:
       "old_class_prefix"  string => canonify("variable_dict_from_file_${variable_name}");
-      "class_prefix"      string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${variable_prefix}", "${variable_name}", "${file_name}" };
 
       # define the variable within the class_prefix namespace

--- a/tree/30_generic_methods/variable_iterator.cf
+++ b/tree/30_generic_methods/variable_iterator.cf
@@ -46,7 +46,8 @@ bundle agent variable_iterator(variable_prefix, variable_name, value, separator)
 {
   vars:
       "old_class_prefix"  string => canonify("variable_iterator_${variable_name}");
-      "class_prefix"      string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${variable_prefix}", "${variable_name}", "${value}", "${separator}" };
 
       # define the variable within the class_prefix namespace

--- a/tree/30_generic_methods/variable_iterator_from_file.cf
+++ b/tree/30_generic_methods/variable_iterator_from_file.cf
@@ -48,7 +48,8 @@ bundle agent variable_iterator_from_file(variable_prefix, variable_name, file_na
 {
   vars:
       "old_class_prefix"  string => canonify("variable_iterator_from_file_${variable_name}");
-      "class_prefix"      string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${variable_prefix}", "${variable_name}", "${file_name}", "${separator_regex}", "${comments_regex}" };
 
       # define the variable within the class_prefix namespace

--- a/tree/30_generic_methods/variable_string.cf
+++ b/tree/30_generic_methods/variable_string.cf
@@ -40,7 +40,8 @@ bundle agent variable_string(variable_prefix, variable_name, value)
 {
   vars:
       "old_class_prefix"  string => canonify("variable_string_${variable_name}");
-      "class_prefix"      string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"               slist => { "${variable_prefix}", "${variable_name}", "${value}" };
 
       # define the variable within the class_prefix namespace

--- a/tree/30_generic_methods/variable_string_from_file.cf
+++ b/tree/30_generic_methods/variable_string_from_file.cf
@@ -41,7 +41,8 @@ bundle agent variable_string_from_file(variable_prefix, variable_name, file_name
 {
   vars:
       "old_class_prefix"  string => canonify("variable_string_from_file_${variable_name}");
-      "class_prefix"      string => canonify(join("_", "this.callers_promisers"));
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${variable_prefix}", "${variable_name}", "${file_name}" };
 
       # define the variable within the class_prefix namespace


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7459