### PR TITLE
Fixes #7483: list_compatible_input doesn't list 3.6 specific files

### DIFF
--- a/tree/10_ncf_internals/list-compatible-inputs
+++ b/tree/10_ncf_internals/list-compatible-inputs
@@ -21,8 +21,8 @@ export PATH
 
 # split version numbers
 version_regex='\([0-9][0-9]*\)\.\([0-9][0-9]*\).*'
-cfengine_major=`printf ${cfengine_version} | sed -e "s/${version_regex}/\\1/"`
-cfengine_minor=`printf ${cfengine_version} | sed -e "s/${version_regex}/\\2/"`
+cfengine_major=`printf "${cfengine_version}\n" | sed -e "s/${version_regex}/\\1/"`
+cfengine_minor=`printf "${cfengine_version}\n" | sed -e "s/${version_regex}/\\2/"`
 
 # Last parameters not named to keep them as a quoted array
 for directory in "$@"


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7483