### PR TITLE
Fixes #7553: ncf 1.x show debug messages with unknown promisers and args lists

### DIFF
--- a/tree/30_generic_methods/_log_default.cf
+++ b/tree/30_generic_methods/_log_default.cf
@@ -45,7 +45,7 @@ bundle agent _log_default(message, old_class_prefix, origin_class_prefix, args)
     "arg_list" string => join(",", "args");
 
   reports:
-    debug::
+    debug.has_promiser_stack::
       "${configuration.debug} Promise called ${promisers} with ${arg_list}"; # full debug information
 
     debug.!has_promiser_stack::


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7553