### PR TITLE
Fixes #7694: service_check_running report misleading always says it uses 'ps'

### DIFF
--- a/tree/30_generic_methods/service_check_running.cf
+++ b/tree/30_generic_methods/service_check_running.cf
@@ -47,5 +47,5 @@ bundle agent service_check_running(service_name)
 
     any::
       "new result classes"    usebundle => _classes_copy("${class_prefix}_check_running", "${class_prefix}");
-      "report"                usebundle => _log("Check if the service ${service_regex} is started using ps", "", "${class_prefix}", @{args});
+      "report"                usebundle => _log("Check if the service ${service_regex} is started", "${old_class_prefix}", "${class_prefix}", @{args});
 }


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7694