### PR TITLE
Fixes #7864: Add new checks for special file types

### DIFF
--- a/tests/acceptance/30_generic_methods/file_check_FIFO_pipe.cf
+++ b/tests/acceptance/30_generic_methods/file_check_FIFO_pipe.cf
@@ -1,0 +1,89 @@
+#########################################
+#
+# Test checking if a file is a FIFO or not 
+# 
+#########################################
+
+bundle common acc_path
+{
+  vars:
+    "root" string => getenv("NCF_TESTS_ACCEPTANCE", 1024);
+}
+
+body common control
+{
+      inputs => { "${acc_path.root}/default.cf.sub", "${acc_path.root}/default_ncf.cf.sub", "@{ncf_inputs.default_files}" };
+      bundlesequence  => { configuration, default("${this.promise_filename}") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+    "tmp"            string => getenv("TEMP", 1024);
+    "file"           string => "${tmp}/test";
+    "file_canon"     string => canonify("${file}");
+
+    "FIFO_pipe"        string => "${tmp}/FIFO_pipe";
+    "FIFO_pipe_canon"  string => canonify("${FIFO_pipe}");
+
+    "file_list"       slist => { "${file}", "${FIFO_pipe}" };
+
+  files:
+    "${file}"
+      create => "true";
+
+  commands:
+    "/usr/bin/mkfifo"
+      args => "-m 640 \"${FIFO_pipe}\"";
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+    "fce" usebundle => file_check_FIFO_pipe("${init.file_list}");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    # Check file type
+    "test_file_type"          string => "/usr/bin/file -b \"${init.file}\"";
+
+    # Check FIFO_pipe type
+    "test_FIFO_pipe_type"     string => "/usr/bin/file -b \"${init.FIFO_pipe}\"";
+
+  classes:
+    "test_file_is_FIFO_pipe"
+      expression => strcmp("fifo (named pipe)", execresult("${test_file_type}", "noshell") ),
+      ifvarclass => "file_check_FIFO_pipe_${init.file_canon}_reached";
+
+    "test_FIFO_pipe_is_FIFO_pipe"
+      expression => strcmp("fifo (named pipe)", execresult("${test_FIFO_pipe_type}", "noshell") ),
+      ifvarclass => "file_check_FIFO_pipe_${init.FIFO_pipe_canon}_reached";
+
+    "ok"   expression => "test_FIFO_pipe_is_FIFO_pipe.file_check_FIFO_pipe_${init.FIFO_pipe_canon}_ok.!test_file_is_FIFO_pipe.!file_check_FIFO_pipe_${init.file_canon}_ok.file_check_FIFO_pipe_${init.file_canon}_reached";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+    !test_FIFO_pipe_is_FIFO_pipe::
+      "${init.FIFO_pipe} is not a FIFO_pipe as expected. It is '${test_FIFO_pipe_type}'";
+    test_file_is_FIFO_pipe::
+      "${init.file} is a FIFO_pipe, not as expected. It is '${test_file_type}'";
+
+    cfengine::
+      "Check of ${init.file} is not reached"
+        ifvarclass => "!file_check_FIFO_pipe_${init.file_canon}_reached";
+      "Check of ${init.FIFO_pipe} is not reached"
+        ifvarclass => "!file_check_FIFO_pipe_${init.FIFO_pipe_canon}_reached";
+
+}

--- a/tests/acceptance/30_generic_methods/file_check_block_device.cf
+++ b/tests/acceptance/30_generic_methods/file_check_block_device.cf
@@ -1,0 +1,89 @@
+#########################################
+#
+# Test checking if a block device or not 
+# 
+#########################################
+
+bundle common acc_path
+{
+  vars:
+    "root" string => getenv("NCF_TESTS_ACCEPTANCE", 1024);
+}
+
+body common control
+{
+      inputs => { "${acc_path.root}/default.cf.sub", "${acc_path.root}/default_ncf.cf.sub", "@{ncf_inputs.default_files}" };
+      bundlesequence  => { configuration, default("${this.promise_filename}") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+    "tmp"            string => getenv("TEMP", 1024);
+    "file"           string => "${tmp}/test";
+    "file_canon"     string => canonify("${file}");
+
+    "block_device"        string => "${tmp}/block_device";
+    "block_device_canon"  string => canonify("${block_device}");
+
+    "file_list"       slist => { "${file}", "${block_device}" };
+
+  files:
+    "${file}"
+      create => "true";
+
+  commands:
+    "/bin/mknod"
+      args => "-m 640 \"${block_device}\" b 7 0"; # /dev/loop0
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+    "fce" usebundle => file_check_block_device("${init.file_list}");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    # Check file type
+    "test_file_type"        string => "/usr/bin/file -b \"${init.file}\"";
+
+    # Check block_device type
+    "test_block_device_type"     string => "/usr/bin/file -b \"${init.block_device}\"";
+
+  classes:
+    "test_file_is_block_device"
+      expression => strcmp("block special", execresult("${test_file_type}", "noshell") ),
+      ifvarclass => "file_check_block_device_${init.file_canon}_reached";
+
+    "test_block_device_is_block_device"
+      expression => strcmp("block special", execresult("${test_block_device_type}", "noshell") ),
+      ifvarclass => "file_check_block_device_${init.block_device_canon}_reached";
+
+    "ok"   expression => "test_block_device_is_block_device.file_check_block_device_${init.block_device_canon}_ok.!test_file_is_block_device.!file_check_block_device_${init.file_canon}_ok.file_check_block_device_${init.file_canon}_reached";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+    !test_block_device_is_block_device::
+      "${init.block_device} is not a block_device as expected. It is '${test_block_device_type}'";
+    test_file_is_block_device::
+      "${init.file} is a block_device, not as expected. It is '${test_file_type}'";
+
+    cfengine::
+      "Check of ${init.file} is not reached"
+        ifvarclass => "!file_check_block_device_${init.file_canon}_reached";
+      "Check of ${init.block_device} is not reached"
+        ifvarclass => "!file_check_block_device_${init.block_device_canon}_reached";
+
+}

--- a/tests/acceptance/30_generic_methods/file_check_character_device.cf
+++ b/tests/acceptance/30_generic_methods/file_check_character_device.cf
@@ -1,0 +1,89 @@
+#########################################
+#
+# Test checking if a character device or not 
+# 
+#########################################
+
+bundle common acc_path
+{
+  vars:
+    "root" string => getenv("NCF_TESTS_ACCEPTANCE", 1024);
+}
+
+body common control
+{
+      inputs => { "${acc_path.root}/default.cf.sub", "${acc_path.root}/default_ncf.cf.sub", "@{ncf_inputs.default_files}" };
+      bundlesequence  => { configuration, default("${this.promise_filename}") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+    "tmp"            string => getenv("TEMP", 1024);
+    "file"           string => "${tmp}/test";
+    "file_canon"     string => canonify("${file}");
+
+    "character_device"        string => "${tmp}/character_device";
+    "character_device_canon"  string => canonify("${character_device}");
+
+    "file_list"       slist => { "${file}", "${character_device}" };
+
+  files:
+    "${file}"
+      create => "true";
+
+  commands:
+    "/bin/mknod"
+      args => "-m 640 \"${character_device}\" c 5 1"; # /dev/console
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+    "fce" usebundle => file_check_character_device("${init.file_list}");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    # Check file type
+    "test_file_type"        string => "/usr/bin/file -b \"${init.file}\"";
+
+    # Check character_device type
+    "test_character_device_type"     string => "/usr/bin/file -b \"${init.character_device}\"";
+
+  classes:
+    "test_file_is_character_device"
+      expression => strcmp("character special", execresult("${test_file_type}", "noshell") ),
+      ifvarclass => "file_check_character_device_${init.file_canon}_reached";
+
+    "test_character_device_is_character_device"
+      expression => strcmp("character special", execresult("${test_character_device_type}", "noshell") ),
+      ifvarclass => "file_check_character_device_${init.character_device_canon}_reached";
+
+    "ok"   expression => "test_character_device_is_character_device.file_check_character_device_${init.character_device_canon}_ok.!test_file_is_character_device.!file_check_character_device_${init.file_canon}_ok.file_check_character_device_${init.file_canon}_reached";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+    !test_character_device_is_character_device::
+      "${init.character_device} is not a character_device as expected. It is '${test_character_device_type}'";
+    test_file_is_character_device::
+      "${init.file} is a character_device, not as expected. It is '${test_file_type}'";
+
+    cfengine::
+      "Check of ${init.file} is not reached"
+        ifvarclass => "!file_check_character_device_${init.file_canon}_reached";
+      "Check of ${init.character_device} is not reached"
+        ifvarclass => "!file_check_character_device_${init.character_device_canon}_reached";
+
+}

--- a/tests/acceptance/30_generic_methods/file_check_hardlink.cf
+++ b/tests/acceptance/30_generic_methods/file_check_hardlink.cf
@@ -1,0 +1,98 @@
+#########################################
+#
+# Test checking if a file is hardlinked to an other or not 
+# 
+#########################################
+
+bundle common acc_path
+{
+  vars:
+    "root" string => getenv("NCF_TESTS_ACCEPTANCE", 1024);
+}
+
+body common control
+{
+      inputs => { "${acc_path.root}/default.cf.sub", "${acc_path.root}/default_ncf.cf.sub", "@{ncf_inputs.default_files}" };
+      bundlesequence  => { configuration, default("${this.promise_filename}") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+    "tmp"            string => getenv("TEMP", 1024);
+
+    "file"           string => "${tmp}/test";
+    "file_canon"     string => canonify("${file}");
+
+    "file2"          string => "${tmp}/test2";
+    "file2_canon"    string => canonify("${file2}");
+
+    "hardlink"        string => "${tmp}/hardlink";
+    "hardlink_canon"  string => canonify("${hardlink}");
+
+    "file_list"       slist => { "${file}", "${hardlink}" };
+
+  files:
+    "${file}"
+      create => "true";
+
+    "${file2}"
+      create => "true";
+
+    "${hardlink}"
+      link_from => linkfrom("${file}", "hardlink");
+
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+    "positive"  usebundle => file_check_hardlink("${init.file}",  "${init.hardlink}");
+    "negative"  usebundle => file_check_hardlink("${init.file2}", "${init.hardlink}");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    # Check file type
+    "test_file_devino"        string => "/bin/stat -c %d:%i \"${init.file}\"";
+    "test_file2_devino"       string => "/bin/stat -c %d:%i \"${init.file2}\"";
+
+    # Check hardlink type
+    "test_hardlink_devino"    string => "/bin/stat -c %d:%i \"${init.hardlink}\"";
+
+  classes:
+    "test_hardlink_is_hardlink"
+      expression => strcmp( execresult("${test_file_devino}", "noshell"), execresult("${test_hardlink_devino}", "noshell") ),
+      ifvarclass => "file_check_hardlink_${init.file_canon}_reached";
+
+    "test_file_is_hardlink"
+      expression => strcmp( execresult("${test_file2_devino}", "noshell"), execresult("${test_hardlink_devino}", "noshell") ),
+      ifvarclass => "file_check_hardlink_${init.file2_canon}_reached";
+
+    "ok"   expression => "test_hardlink_is_hardlink.file_check_hardlink_${init.file_canon}_ok.!test_file_is_hardlink.!file_check_hardlink_${init.file2_canon}_ok.file_check_hardlink_${init.file2_canon}_reached";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+    !test_hardlink_is_hardlink::
+      "${init.file} and ${init.hardlink} are not a hardlinked as expected. ";
+    test_file_is_hardlink::
+      "${init.file2} and ${init.hardlink} are hardlinks, not as expected.'";
+
+    cfengine::
+      "Check of ${init.file} is not reached"
+        ifvarclass => "!file_check_hardlink_${init.file_canon}_reached";
+      "Check of ${init.hardlink} is not reached"
+        ifvarclass => "!file_check_hardlink_${init.hardlink_canon}_reached";
+
+}

--- a/tests/acceptance/30_generic_methods/file_check_regular.cf
+++ b/tests/acceptance/30_generic_methods/file_check_regular.cf
@@ -1,0 +1,88 @@
+#########################################
+#
+# Test checking if a file is a regular file or not
+# 
+#########################################
+
+bundle common acc_path
+{
+  vars:
+    "root" string => getenv("NCF_TESTS_ACCEPTANCE", 1024);
+}
+
+body common control
+{
+      inputs => { "${acc_path.root}/default.cf.sub", "${acc_path.root}/default_ncf.cf.sub", "@{ncf_inputs.default_files}" };
+      bundlesequence  => { configuration, default("${this.promise_filename}") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+    "tmp"            string => getenv("TEMP", 1024);
+    "file"           string => "${tmp}/test";
+    "file_canon"     string => canonify("${file}");
+
+    "symlink"        string => "${tmp}/symlink";
+    "symlink_canon"  string => canonify("${symlink}");
+
+    "file_list"       slist => { "${file}", "${symlink}" };
+
+  files:
+    "${file}"
+      create => "true";
+
+    "${symlink}"
+      link_from => ln_s("${file}");
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+    "fce" usebundle => file_check_regular("${init.file_list}");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    # Check file type
+    "test_file_type"        string => "/usr/bin/file -b \"${init.file}\"";
+
+    # Check symlink type
+    "test_symlink_type"     string => "/usr/bin/file -b \"${init.symlink}\"";
+
+  classes:
+    "test_file_is_regular"
+      expression => strcmp("empty", execresult("${test_file_type}", "noshell") ),
+      ifvarclass => "file_check_regular_${init.file_canon}_reached";
+
+    "test_symlink_is_regular"
+      expression => regcmp("empty", execresult("${test_symlink_type}", "noshell") ),
+      ifvarclass => "file_check_regular_${init.symlink_canon}_reached";
+
+    "ok"   expression => "test_file_is_regular.file_check_regular_${init.file_canon}_ok.!test_symlink_is_regular.!file_check_regular_${init.symlink_canon}_ok.file_check_regular_${init.symlink_canon}_reached";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+    test_symlink_is_regular::
+      "${init.symlink} is a regular, not as expected.";
+    !test_file_is_regular::
+      "${init.file} is not a regular as expected.";
+
+    cfengine::
+      "Check of ${init.file} is not reached"
+        ifvarclass => "!file_check_regular_${init.file_canon}_reached";
+      "Check of ${init.symlink} is not reached"
+        ifvarclass => "!file_check_regular_${init.symlink_canon}_reached";
+
+}

--- a/tests/acceptance/30_generic_methods/file_check_socket.cf
+++ b/tests/acceptance/30_generic_methods/file_check_socket.cf
@@ -1,0 +1,86 @@
+#########################################
+#
+# Test checking if a file is a socket or not 
+# 
+#########################################
+
+bundle common acc_path
+{
+  vars:
+    "root" string => getenv("NCF_TESTS_ACCEPTANCE", 1024);
+}
+
+body common control
+{
+      inputs => { "${acc_path.root}/default.cf.sub", "${acc_path.root}/default_ncf.cf.sub", "@{ncf_inputs.default_files}" };
+      bundlesequence  => { configuration, default("${this.promise_filename}") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+    "tmp"           string => getenv("TEMP", 1024);
+    "file"          string => "${tmp}/test";
+    "file_canon"    string => canonify("${file}");
+
+    "socket"        string => execresult("/bin/readlink -f /dev/log", "noshell"); # this should always point to a socket
+    "socket_canon"  string => canonify("${socket}");
+
+    "file_list"      slist => { "${file}", "${socket}" };
+
+  files:
+    "${file}"
+      create => "true";
+
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+    "fce" usebundle => file_check_socket("${init.file_list}");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    # Check file type
+    "test_file_type"       string => "/usr/bin/file -b \"${init.file}\"";
+
+    # Check socket type
+    "test_socket_type"     string => "/usr/bin/file -b \"${init.socket}\"";
+
+  classes:
+    "test_file_is_socket"
+      expression => strcmp("socket", execresult("${test_file_type}", "noshell") ),
+      ifvarclass => "file_check_socket_${init.file_canon}_reached";
+
+    "test_socket_is_socket"
+      expression => strcmp("socket", execresult("${test_socket_type}", "noshell") ),
+      ifvarclass => "file_check_socket_${init.socket_canon}_reached";
+
+    "ok"   expression => "test_socket_is_socket.file_check_socket_${init.socket_canon}_ok.!test_file_is_socket.!file_check_socket_${init.file_canon}_ok.file_check_socket_${init.file_canon}_reached";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+    !test_socket_is_socket::
+      "${init.socket} is not a socket as expected. It is '${test_socket_type}'";
+    test_file_is_socket::
+      "${init.file} is a socket, not as expected. It is '${test_file_type}'";
+
+    cfengine::
+      "Check of ${init.file} is not reached"
+        ifvarclass => "!file_check_socket_${init.file_canon}_reached";
+      "Check of ${init.socket} is not reached"
+        ifvarclass => "!file_check_socket_${init.socket_canon}_reached";
+
+}

--- a/tests/acceptance/30_generic_methods/file_check_symlink.cf
+++ b/tests/acceptance/30_generic_methods/file_check_symlink.cf
@@ -1,0 +1,88 @@
+#########################################
+#
+# Test checking if a file is a symlink or not 
+# 
+#########################################
+
+bundle common acc_path
+{
+  vars:
+    "root" string => getenv("NCF_TESTS_ACCEPTANCE", 1024);
+}
+
+body common control
+{
+      inputs => { "${acc_path.root}/default.cf.sub", "${acc_path.root}/default_ncf.cf.sub", "@{ncf_inputs.default_files}" };
+      bundlesequence  => { configuration, default("${this.promise_filename}") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+    "tmp"            string => getenv("TEMP", 1024);
+    "file"           string => "${tmp}/test";
+    "file_canon"     string => canonify("${file}");
+
+    "symlink"        string => "${tmp}/symlink";
+    "symlink_canon"  string => canonify("${symlink}");
+
+    "file_list"       slist => { "${file}", "${symlink}" };
+
+  files:
+    "${file}"
+      create => "true";
+
+    "${symlink}"
+      link_from => ln_s("${file}");
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+    "fce" usebundle => file_check_symlink("${init.file_list}");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    # Check file type
+    "test_file_type"        string => "/usr/bin/file -b \"${init.file}\"";
+
+    # Check symlink type
+    "test_symlink_type"     string => "/usr/bin/file -b \"${init.symlink}\"";
+
+  classes:
+    "test_file_is_symlink"
+      expression => regcmp("^symbolic link to.*", execresult("${test_file_type}", "noshell") ),
+      ifvarclass => "file_check_symlink_${init.file_canon}_reached";
+
+    "test_symlink_is_symlink"
+      expression => regcmp("^symbolic link to.*", execresult("${test_symlink_type}", "noshell") ),
+      ifvarclass => "file_check_symlink_${init.symlink_canon}_reached";
+
+    "ok"   expression => "test_symlink_is_symlink.file_check_symlink_${init.symlink_canon}_ok.!test_file_is_symlink.!file_check_symlink_${init.file_canon}_ok.file_check_symlink_${init.file_canon}_reached";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+    !test_symlink_is_symlink::
+      "${init.symlink} is not a symlink as expected. It is '${test_symlink_type}'";
+    test_file_is_symlink::
+      "${init.file} is a symlink, not as expected. It is '${test_file_type}'";
+
+    cfengine::
+      "Check of ${init.file} is not reached"
+        ifvarclass => "!file_check_symlink_${init.file_canon}_reached";
+      "Check of ${init.symlink} is not reached"
+        ifvarclass => "!file_check_symlink_${init.symlink_canon}_reached";
+
+}

--- a/tests/acceptance/30_generic_methods/file_check_symlinkto.cf
+++ b/tests/acceptance/30_generic_methods/file_check_symlinkto.cf
@@ -1,0 +1,96 @@
+#########################################
+#
+# Test checking if a file is a symlink to a file or not 
+# 
+#########################################
+
+bundle common acc_path
+{
+  vars:
+    "root" string => getenv("NCF_TESTS_ACCEPTANCE", 1024);
+}
+
+body common control
+{
+      inputs => { "${acc_path.root}/default.cf.sub", "${acc_path.root}/default_ncf.cf.sub", "@{ncf_inputs.default_files}" };
+      bundlesequence  => { configuration, default("${this.promise_filename}") };
+      version => "1.0";
+}
+
+#######################################################
+
+bundle agent init
+{
+  vars:
+    "tmp"            string => getenv("TEMP", 1024);
+    "file"           string => "${tmp}/test";
+
+    "symlink_good_name"     string => "${tmp}/symlink_good";
+    "symlink_good_target"   string => "${file}";
+    "symlink_good_canon"    string => canonify("${symlink_good_name}");
+
+    "symlink_bad_name"      string => "${tmp}/symlink_bad";
+    "symlink_bad_target"    string => "/dev/null";
+    "symlink_bad_canon"     string => canonify("${symlink_bad_name}");
+
+    "symlink_list"           slist => { "${symlink_good_name}", "${symlink_bad_name}" };
+
+  files:
+    "${file}"
+      create => "true";
+
+    "${symlink_good_name}"
+      link_from => ln_s("${symlink_good_target}");
+
+    "${symlink_bad_name}"
+      link_from => ln_s("${symlink_bad_target}");
+
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+    "fce" usebundle => file_check_symlinkto("${init.symlink_list}", "${init.file}");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    # Check symlink_good target
+    "test_good_target"       string => "/usr/bin/file -b \"${init.symlink_good_name}\"";
+
+    # Check symlink type
+    "test_bad_target"        string => "/usr/bin/file -b \"${init.symlink_bad_name}\"";
+
+  classes:
+    "symlink_good_is_ok"
+      expression => strcmp("symbolic link to `${init.symlink_good_target}'", execresult("${test_good_target}", "noshell") ),
+      ifvarclass => "file_check_symlinkto_${init.symlink_good_canon}_reached";
+
+    "symlink_bad_is_ok"
+      expression => strcmp("symbolic link to `${init.symlink_good_target}'",  execresult("${test_bad_target}", "noshell") ),
+      ifvarclass => "file_check_symlinkto_${init.symlink_bad_canon}_reached";
+
+    "ok"   expression => "symlink_good_is_ok.file_check_symlinkto_${init.symlink_good_canon}_ok.!symlink_bad_is_ok.!file_check_symlinkto_${init.symlink_bad_canon}_ok.file_check_symlinkto_${init.symlink_bad_canon}_reached";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+    !symlink_good_is_ok::
+      "${init.symlink_good_name} is a symlink not pointing to where expected";
+    symlink_bad_is_ok::
+      "${init.symlink_bad_name} is a symlink pointing to where not expected.";
+
+    cfengine::
+      "Check of ${init.symlink_good_name} is not reached"
+        ifvarclass => "!file_check_symlinkto_${init.symlink_good_canon}_reached";
+      "Check of ${init.symlink_bad_name} is not reached"
+        ifvarclass => "!file_check_symlinkto_${init.symlink_bad_canon}_reached";
+
+}

--- a/tree/30_generic_methods/_file_check_special.cf
+++ b/tree/30_generic_methods/_file_check_special.cf
@@ -1,0 +1,56 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+# Copyright 2016 Janos Mattyasovszky
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name File check is special
+# @description Checks if a file exists and is a special file
+#
+# @parameter file_name File name
+# @parameter file_type File type
+# 
+# @class_prefix file_check_special
+# @class_parameter file_name 
+# This bundle will define a class file_check_${file_type}_${file_name}_{ok, reached, kept} if the
+# file is a special file of type ${file_type}, or file_check_${file_type}_${file_name}_{not_ok, reached, not_kept, failed} if
+# the file is not a special file or does not exist
+
+bundle agent file_check_special(file_name, file_type)
+{
+  vars:
+      "file_has_type"       string => filestat("${file_name}", "type");
+      "class_prefix"        string => canonify("file_check_${file_type}_${file_name}");
+
+  classes:
+      "file_exists"     expression => fileexists("${file_name}");
+      "file_is_special" expression => strcmp("${file_has_type}", "${file_type}");
+      "exists_special"  expression => "file_exists.file_is_special";
+
+
+  methods:
+    exists_special::
+      "file_exists_and_is_special"
+        usebundle => _classes_success("${class_prefix}");
+
+    !exists_special::
+      "file_doesnt_exists_or_is_not_special"
+        usebundle => _classes_failure("${class_prefix}");
+
+    any::
+      "report"
+        usebundle => _logger("Check if ${file_name} exists and is a ${file_type}", "${class_prefix}");
+}

--- a/tree/30_generic_methods/file_check_FIFO_pipe.cf
+++ b/tree/30_generic_methods/file_check_FIFO_pipe.cf
@@ -1,0 +1,38 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+# Copyright 2016 Janos Mattyasovszky
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name File check is FIFO/Pipe
+# @description Checks if a file exists and is a FIFO/Pipe
+#
+# @parameter file_name File name
+# 
+# @class_prefix file_check_FIFO_pipe
+# @class_parameter file_name
+# This bundle will define a class file_check_FIFO_pipe_${file_name}_{ok, reached, kept} if the
+# file is a FIFO, or file_check_FIFO_pipe_${file_name}_{not_ok, reached, not_kept, failed} if
+# the file is not a fifo or does not exist
+
+bundle agent file_check_FIFO_pipe(file_name)
+{
+
+  methods:
+      "file_exists"
+        usebundle => file_check_special("${file_name}", "FIFO/pipe");
+
+}

--- a/tree/30_generic_methods/file_check_block_device.cf
+++ b/tree/30_generic_methods/file_check_block_device.cf
@@ -1,0 +1,37 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+# Copyright 2016 Janos Mattyasovszky
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name File check if block device
+# @description Checks if a file exists and is a block device
+#
+# @parameter file_name File name
+# 
+# @class_prefix file_check_block_device
+# @class_parameter file_name
+# This bundle will define a class file_check_block_device_${file_name}_{ok, reached, kept} if the
+# file is a block_device, or file_check_block_device_${file_name}_{not_ok, reached, not_kept, failed} if
+# the file is not a block device or does not exist
+
+bundle agent file_check_block_device(file_name)
+{
+    methods:
+      "file_exists_and_is_block_device"
+        usebundle => file_check_special( "${file_name}", "block device");
+
+}

--- a/tree/30_generic_methods/file_check_character_device.cf
+++ b/tree/30_generic_methods/file_check_character_device.cf
@@ -1,0 +1,37 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+# Copyright 2016 Janos Mattyasovszky
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name File check if character device
+# @description Checks if a file exists and is a character device
+#
+# @parameter file_name File name
+# 
+# @class_prefix file_check_character_device
+# @class_parameter file_name
+# This bundle will define a class file_check_character_device_${file_name}_{ok, reached, kept} if the
+# file is a character device, or file_check_character_device_${file_name}_{not_ok, reached, not_kept, failed} if
+# the file is not a character device or does not exist
+
+bundle agent file_check_character_device(file_name)
+{
+    methods:
+      "file_exists_and_is_character_device"
+        usebundle => file_check_special( "${file_name}", "character device");
+
+}

--- a/tree/30_generic_methods/file_check_hardlink.cf
+++ b/tree/30_generic_methods/file_check_hardlink.cf
@@ -1,0 +1,62 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+# Copyright 2016 Janos Mattyasovszky
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name File check is hardlink
+# @description Checks if two files are the same (hard links)
+#
+# @parameter file_name_1   File name #1
+# @parameter file_name_2   File name #2
+# 
+# @class_prefix file_check_hardlink
+# @class_parameter file_name_1
+# This bundle will define a class file_check_hardlink_${file_name_1}_{ok, reached, kept} if the
+# two files ${file_name_1} and ${file_name_2} are hard links of each other, or file_check_hardlink_${file_name_1}_{not_ok, reached, not_kept, failed} if
+# if the files are not hard links.
+
+bundle agent file_check_hardlink(file_name_1, file_name_2)
+{
+  vars:
+      "class_prefix"        string => canonify("file_check_hardlink_${file_name_1}");
+      "file_1_devno"        string => filestat("${file_name_1}", "devno");
+      "file_1_ino"          string => filestat("${file_name_1}", "ino");
+      "file_2_devno"        string => filestat("${file_name_2}", "devno");
+      "file_2_ino"          string => filestat("${file_name_2}", "ino");
+
+
+  classes:
+      "file_1_exists"           expression => fileexists("${file_name_1}");
+      "file_2_exists"           expression => fileexists("${file_name_2}");
+      "files_match_device"      expression => strcmp("${file_1_devno}", "${file_2_devno}");
+      "files_match_inode"       expression => strcmp("${file_1_ino}",   "${file_2_ino}");
+      "files_are_hardlinks"     expression => "file_1_exists.file_2_exists.files_match_device.files_match_inode";
+
+
+  methods:
+    files_are_hardlinks::
+      "files_are_hardlinks"
+        usebundle => _classes_success("${class_prefix}");
+
+    !files_are_hardlinks::
+      "files_are_not_hardlinks"
+        usebundle => _classes_failure("${class_prefix}");
+
+    any::
+      "report"
+        usebundle => _logger("Check if ${file_name_1} and ${file_name_2} are the same", "${class_prefix}");
+}

--- a/tree/30_generic_methods/file_check_regular.cf
+++ b/tree/30_generic_methods/file_check_regular.cf
@@ -1,0 +1,54 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+# Copyright 2016 Janos Mattyasovszky
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name File check if regular 
+# @description Checks if a file exists and is a regular file
+#
+# @parameter file_name File name
+# 
+# @class_prefix file_check_regular
+# @class_parameter file_name
+# This bundle will define a class file_check_regular_${file_name}_{ok, reached, kept} if the
+# file is a regular_file, or file_check_regular_${file_name}_{not_ok, reached, not_kept, failed} if
+# the file is not a regular file or does not exist
+
+bundle agent file_check_regular(file_name)
+{
+
+  vars:
+      "class_prefix"
+        string => canonify("file_check_regular_${file_name}");
+
+  classes:
+      "file_exists_and_is_regular"  
+        expression => isplain("${file_name}");
+
+  methods:
+    file_exists_and_is_regular::
+      "file_exists_and_is_regular"
+        usebundle => _classes_success("${class_prefix}");
+
+    !file_exists_and_is_regular::
+      "file_dont_exists_or_is_not_a_regular"
+        usebundle => _classes_failure("${class_prefix}");
+
+    any::
+      "report"
+        usebundle => _logger("Check if ${file_name} is a regular file", "${class_prefix}");
+}

--- a/tree/30_generic_methods/file_check_socket.cf
+++ b/tree/30_generic_methods/file_check_socket.cf
@@ -1,0 +1,37 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+# Copyright 2016 Janos Mattyasovszky
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name File check if socket
+# @description Checks if a file exists and is a socket
+#
+# @parameter file_name File name
+# 
+# @class_prefix file_check_socket
+# @class_parameter file_name
+# This bundle will define a class file_check_socket_${file_name}_{ok, reached, kept} if the
+# file is a socket, or file_check_socket_${file_name}_{not_ok, reached, not_kept, failed} if
+# the file is not a socket or does not exist
+
+bundle agent file_check_socket(file_name)
+{
+    methods:
+      "file_exists_and_is_socket"
+        usebundle => file_check_special( "${file_name}", "socket");
+
+}

--- a/tree/30_generic_methods/file_check_symlink.cf
+++ b/tree/30_generic_methods/file_check_symlink.cf
@@ -1,0 +1,53 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+# Copyright 2016 Janos Mattyasovszky
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name File check if symlink
+# @description Checks if a file exists and is a symlink
+#
+# @parameter file_name File name
+# 
+# @class_prefix file_check_symlink
+# @class_parameter file_name
+# This bundle will define a class file_check_symlink_${file_name}_{ok, reached, kept} if the
+# file is a symlink, or file_check_symlink_${file_name}_{not_ok, reached, not_kept, failed} if
+# the file is not a symlink or does not exist
+
+bundle agent file_check_symlink(file_name)
+{
+  vars:
+      "class_prefix"
+        string => canonify("file_check_symlink_${file_name}");
+
+  classes:
+      "file_exists_and_is_symlink"  
+        expression => islink("${file_name}");
+
+  methods:
+    file_exists_and_is_symlink::
+      "file_exists_and_is_symlink"
+        usebundle => _classes_success("${class_prefix}");
+
+    !file_exists_and_is_symlink::
+      "file_dont_exists_or_is_not_a_symlink"
+        usebundle => _classes_failure("${class_prefix}");
+
+    any::
+      "report"
+        usebundle => _logger("Check if ${file_name} is a symlink", "${class_prefix}");
+}

--- a/tree/30_generic_methods/file_check_symlinkto.cf
+++ b/tree/30_generic_methods/file_check_symlinkto.cf
@@ -1,0 +1,58 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+# Copyright 2016 Janos Mattyasovszky
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name         File check is symlink to
+# @description  Checks if first file is symlink to second file
+#
+# @parameter symlink Symbolic link (absolute path)
+# @parameter target Target file (absolute path)
+# 
+# @class_prefix file_check_symlinkto
+# @class_parameter symlink
+# This bundle will define a class file_check_symlinkto_${target}_{ok, reached, kept} if the file ${symlink}
+# is a symbolic link to ${target}, or file_check_symlinkto_${target}_{not_ok, reached, not_kept, failed} if
+# if it is not a symbolic link, or any of the files does not exist. The symlink's path is resolved to the 
+# absolute path and checked against the target file's path, which must also be an absolute path.
+
+bundle agent file_check_symlinkto(symlink, target)
+{
+  vars:
+      "class_prefix"        string => canonify("file_check_symlinkto_${symlink}");
+      "real_path"           string => execresult("/bin/readlink -f \"${symlink}\"", "noshell");
+
+  classes:
+      "file_exists"         expression => fileexists("${target}");
+      "symlink_to_file"     expression => strcmp("${real_path}", "${target}");
+      "is_symlink"          expression => islink("${symlink}");
+      "is_ok"               expression => "file_exists.is_symlink.symlink_to_file";
+
+  methods:
+    is_ok::
+      "symlink_points_to_file"
+        usebundle => _classes_success("${class_prefix}");
+
+    !is_ok::
+      "symlink_does_not_point_to_file"
+        usebundle => _classes_failure("${class_prefix}");
+
+    any::
+      "report"
+        usebundle => _logger("Check if ${symlink} points to ${target}", "${class_prefix}");
+
+}


### PR DESCRIPTION
Check for File being a
- Block device
- Character device
- FIFO/pipe
- Regular file
- Hardlink to an another file
- Socket
- Symlink