### PR TITLE
Fixes #7882: make curl follow redirects

### DIFF
--- a/tree/30_generic_methods/http_request_check_status_headers.cf
+++ b/tree/30_generic_methods/http_request_check_status_headers.cf
@@ -49,7 +49,7 @@ bundle agent http_request_check_status_headers(method, url, expected_status, hea
 
   commands:
       "${paths.path[curl]}"
-        args => "-I -s -o /dev/null -w \"%{http_code}\" ${url} -X ${method} -H '${headers}' | /bin/grep -q ${expected_status}",
+        args => "-I -L -s -o /dev/null -w \"%{http_code}\" ${url} -X ${method} -H '${headers}' | /bin/grep -q ${expected_status}",
         contain => in_shell,
         # We don't define repaired class, as we only query and expect, so using 999 to avoid using this feature
         classes => classes_generic_return_codes("${class_prefix}", "0", "999", "1");

--- a/tree/30_generic_methods/http_request_content_headers.cf
+++ b/tree/30_generic_methods/http_request_content_headers.cf
@@ -49,7 +49,7 @@ bundle agent http_request_content_headers(method, url, content, headers)
 
   commands:
       "/bin/echo \"${content}\" | ${paths.path[curl]}"
-        args => "${url} -X ${method} -H '${headers}' -o /dev/null -s -f -d @-",
+        args => "${url} -L -X ${method} -H '${headers}' -o /dev/null -s -f -d @-",
         contain => in_shell,
         classes => classes_generic("${class_prefix}");
 


### PR DESCRIPTION
Example where API gives you a redirect is when the authentication info is given in the URL and after authentication you get forwarded.


```
Q: ".../bin/echo "'{"a":   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
Q: ".../bin/echo "'{"a":                                  Dload  Upload   Total   Spent    Left  Speed
124   249  124   249    0     0  64291      0 --:--:-- --:--:-- --:--:-- 83000
Q: ".../bin/echo "'{"a": <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
Q: ".../bin/echo "'{"a": <html><head>
Q: ".../bin/echo "'{"a": <title>302 Found</title>
Q: ".../bin/echo "'{"a": </head><body>
Q: ".../bin/echo "'{"a": <h1>Found</h1>
Q: ".../bin/echo "'{"a": <p>The document has moved <a href="/tinker/check_mk/login.py?_origtarget=webapi.py?action%3dadd_host">here</a>.</p>
Q: ".../bin/echo "'{"a": </body></html>
```