### PR TITLE
Fixes #8430: logger_rudder can re-read expected_reports_temp even without change, impacting performance significantly

### DIFF
--- a/tree/30_generic_methods/logger_rudder.cf
+++ b/tree/30_generic_methods/logger_rudder.cf
@@ -33,7 +33,7 @@ bundle agent logger_rudder(message, class_prefix)
       "expected_reports_temp"   string => "${expected_reports_source}.tmp";
       "expected_reports_file"   string => "${expected_reports_source}.res";
 
-    (!final_resfile_exists.logger_rudder_temp_resfile_reached|logger_rudder_temp_resfile_repaired)::
+    pass2.(!final_resfile_exists.logger_rudder_temp_resfile_reached|logger_rudder_temp_resfile_repaired)::
       # 2/ If the temporary file has been updated, read it to get all values in an array, and canonify the first entry
       "dim" int => readstringarrayidx("reports", "${expected_reports_temp}", "\s*#[^\n]*", ";;", 9999, 999999);
       "keys" slist => getindices("reports");
@@ -55,6 +55,11 @@ bundle agent logger_rudder(message, class_prefix)
       "keys_defined"     expression => isvariable("keys");
 
       "final_resfile_exists" expression => fileexists("${expected_reports_file}");
+
+    any::
+      "pass3" expression => "pass2";
+      "pass2" expression => "pass1";
+      "pass1" expression => "any";
 
   files:
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8430