### PR TITLE
Fixes #8433: logger_rudder evaluates too late content of temp file, causing it to miss first report

### DIFF
--- a/tree/30_generic_methods/logger_rudder.cf
+++ b/tree/30_generic_methods/logger_rudder.cf
@@ -33,7 +33,7 @@ bundle agent logger_rudder(message, class_prefix)
       "expected_reports_temp"   string => "${expected_reports_source}.tmp";
       "expected_reports_file"   string => "${expected_reports_source}.res";
 
-    pass2.(!final_resfile_exists.logger_rudder_temp_resfile_reached|logger_rudder_temp_resfile_repaired)::
+    pass1.(!final_resfile_exists.logger_rudder_temp_resfile_reached|logger_rudder_temp_resfile_repaired)::
       # 2/ If the temporary file has been updated, read it to get all values in an array, and canonify the first entry
       "dim" int => readstringarrayidx("reports", "${expected_reports_temp}", "\s*#[^\n]*", ";;", 9999, 999999);
       "keys" slist => getindices("reports");


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8433