### PR TITLE
Fixes #8512: Add a makefile target for unsafe tests and add it to the test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 all: clean test doc
 
-test:
+test: test-common
+	cd tests/acceptance/ && ./testall --info
+
+test-unsafe: test-common
+	cd tests/acceptance/ && ./testall --info --unsafe
+
+test-common:
 	[ `id | cut -d\( -f2 | cut -d\) -f1` = 'root' ] || type fakeroot 2>/dev/null || { echo "Not running as root and fakeroot not found." ; exit 1 ; }
 	cd tests/style/ && ./testall
 	cd tests/unit/ && ./testall
-	cd tests/acceptance/ && ./testall --info --no-network
-	cd tests/acceptance/ && ./testall --info
 
 doc:
 	ls tree/30_generic_methods/*.cf | xargs egrep -h "^\s*bundle\s+agent\s+" | sed -r "s/\s*bundle\s+agent\s+//" | sort > doc/all_generic_methods.txt


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8512