### PR TITLE
Fixes #8660: Adapt documetation url of each method to us rudder documentation if editor is used with Rudder

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -77,6 +77,6 @@ At this point you need a running rudder (dev or not) on localhost to access ncf 
 
 to remove this need:
 
-* edit /path/to/ncf/api/ncf_flask_app/views.py
-* Replace line ' available_modules_name = ["Rudder"]' by  available_modules_name = ["None"]
+* Edit /path/to/ncf/api/ncf_flask_app/views.py
+* Set value of 'use_rudder_auth' to False
 

--- a/api/ncf_api_flask_app/views.py
+++ b/api/ncf_api_flask_app/views.py
@@ -12,6 +12,7 @@ NCF_TOOLS_DIR = '/usr/share/ncf/tools'
 sys.path[0:0] = [NCF_TOOLS_DIR]
 
 default_path = ""
+use_rudder_auth = True
 
 import ncf
 import ncf_constraints
@@ -70,7 +71,9 @@ def get_authentication_modules():
   # List of all authentication modules
   authentication_modules = { "Rudder" : check_authentication_from_rudder, "None" : no_authentication }
   # Name of all available modules, should read from a file or ncf path. only Rudder available for now
-  available_modules_name = ["Rudder"]
+  available_modules_name = ["None"]
+  if use_rudder_auth:
+    available_modules_name = ["Rudder"]
 
   available_modules = [ module for module_name, module in authentication_modules.items() if module_name in available_modules_name ]
   return available_modules
@@ -125,6 +128,7 @@ def get_generic_methods():
     path = get_path_from_args(request)
   
     generic_methods = ncf.get_all_generic_methods_metadata(alt_path = path)
+    generic_methods["data"]["usingRudder"] = use_rudder_auth
     resp = jsonify( generic_methods )
     return resp
   except Exception as e:

--- a/builder/index.html
+++ b/builder/index.html
@@ -374,7 +374,7 @@
                                 <div class="panel-heading" style="overflow:hidden">
                                     <h4 class="panel-title">
                                         <span class="pull-left"> {{method.name}}
-                                            <a ng-click="$event.stopPropagation();" target="_blank" ng-href="http://www.ncf.io/pages/reference.html#{{method.bundle_name}}">
+                                            <a ng-click="$event.stopPropagation();" target="_blank" ng-href="{{methodUrl(method, kind)}}">
                                                 <i class="glyphicon glyphicon-info-sign method-actions grey-icon"></i>
                                             </a>
                                         </span>

--- a/builder/js/ncf.js
+++ b/builder/js/ncf.js
@@ -153,6 +153,7 @@ app.controller('ncf-builder', function ($scope, $modal, $http, $log, $location, 
   $scope.selectedMethod;
   // Are we authenticated on the interface
   $scope.authenticated = false;
+  var usingRudder = false;
 
   $scope.CForm = {};
 
@@ -329,6 +330,9 @@ $scope.getMethodsAndTechniques = function () {
         $scope.constraints = response.data.constraints;
         $scope.methodsByCategory = $scope.groupMethodsByCategory();
         $scope.authenticated = true;
+        if (response.data.usingRudder !== undefined) {
+          usingRudder = response.data.usingRudder;
+        }
         // Once we have our methods we can fetch our techniques which depends on them
         $scope.getTechniques();
       } else {
@@ -592,6 +596,14 @@ $scope.groupMethodsByCategory = function () {
       return "";
     }
   };
+
+  $scope.methodUrl = function(method,kind) {
+    if (usingRudder) {
+      return "/rudder-doc/#"+method.bundle_name
+    } else {
+      return "http://www.ncf.io/pages/reference.html#"+method.bundle_name
+    }
+  }
 
   // Get parameters information relative to a method_call
   $scope.getMethodParameters = function(method_call) {


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8660

Replacing previous PR: https://github.com/Normation/ncf/pull/402
