### PR TITLE
Fixes #8721:  Broken service_ensure_running_path test with CFEngine 3.6.7, 3.7.3

### DIFF
--- a/tests/acceptance/30_generic_methods/unsafe/service_ensure_running_path.cf
+++ b/tests/acceptance/30_generic_methods/unsafe/service_ensure_running_path.cf
@@ -22,13 +22,17 @@ body common control
 bundle agent init
 {
   vars:
-    "service_name"  string => "cf-serverd";
-    # here we don't use the full path to support multiple version of agent
-    # plus, the check on the path is not anchored, ensuring that it will
-    # find the right process
-    "service_path"  string => "/bin/cf-serverd";
-    "cservice_name" string => canonify("${service_name}");
-    "cservice_path" string => canonify("${service_path}");
+    debian::
+      "service_name"  string => "ssh";
+    redhat::
+      "service_name"  string => "sshd";
+    any::
+      # here we don't use the full path to support multiple version of agent
+      # plus, the check on the path is not anchored, ensuring that it will
+      # find the right process
+      "service_path"  string => "/sbin/sshd";
+      "cservice_name" string => canonify("${service_name}");
+      "cservice_path" string => canonify("${service_path}");
 }
 
 #######################################################


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8721