### PR TITLE
Fixes #8871: missing rudder_expected_reports.csv.res when starting the agent for the first time after an update

### DIFF
--- a/tree/30_generic_methods/logger_rudder.cf
+++ b/tree/30_generic_methods/logger_rudder.cf
@@ -30,8 +30,12 @@ bundle agent logger_rudder(message, class_prefix)
   vars:
 
       "expected_reports_source" string => "${sys.workdir}/inputs/rudder_expected_reports.csv";
-      "expected_reports_temp"   string => "${expected_reports_source}.tmp";
-      "expected_reports_file"   string => "${expected_reports_source}.res";
+      "expected_reports_destination" string => "${sys.workdir}/state/rudder_expected_reports.${this.promiser_pid}.csv";
+      # We put those files into the state directory to avoid purging them during each update
+      # (which would break the current run's reporting).
+      # We add the PID to the file name to be able to handle cuncurrent agent runs with separate expected reports
+      "expected_reports_temp"   string => "${expected_reports_destination}.tmp";
+      "expected_reports_file"   string => "${expected_reports_destination}.res";
 
     pass1.(!final_resfile_exists.logger_rudder_temp_resfile_reached|logger_rudder_temp_resfile_repaired)::
       # 2/ If the temporary file has been updated, read it to get all values in an array, and canonify the first entry
@@ -91,6 +95,31 @@ bundle agent logger_rudder(message, class_prefix)
       # 4/ Array is ready, reporting time !!!
       "any" usebundle => _rudder_common_reports_generic("${report_data[1]}", "${c_class_prefix}", "${report_data[3]}", "${report_data[4]}", "${report_data[5]}", "${message}"),
         classes    => classes_generic("logger_rudder_${c_class_prefix}");
+
+}
+
+# This bundle will delete the current expected reports file
+# It is supposed to be called at the end of the run
+bundle agent _clean_current_expected_reports_file {
+
+  vars:
+      "files_to_remove" slist => { "${logger_rudder.expected_reports_temp}",
+                                   "${logger_rudder.expected_reports_file}" };
+
+  files:
+      "${files_to_remove}"
+         delete => tidy;
+      
+}
+
+# This bundle will delete expected reports files older than the given age
+# It allows cleaning leftovers from interrupted executions
+bundle agent _clean_old_expected_reports_file(days) {
+
+  files:
+      "${sys.workdir}/state/rudder_expected_reports\.\d+\.csv\.(tmp|res)"
+        delete => tidy,
+        file_select => days_old("${days}");
 
 }
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8871