### PR TITLE
Fixes #8638: file_ensure_lines_present_in_ini_section.cf test fails with CFEngine 3.9

### DIFF
--- a/tree/20_cfe_basics/cfengine/files.39m.cf
+++ b/tree/20_cfe_basics/cfengine/files.39m.cf
@@ -1,0 +1,27 @@
+############################################################################
+##  Copyright (C) CFEngine AS
+##
+##  This program is free software; you can redistribute it and/or modify it
+##  under the terms of the GNU Lesser General Public License LGPL as published by the
+##  Free Software Foundation; version 3.
+##
+##  This program is distributed in the hope that it will be useful,
+##  but WITHOUT ANY WARRANTY; without even the implied warranty of
+##  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+##  GNU General Public License for more details.
+##
+##  To the extent this program is licensed as part of the Enterprise
+##  versions of CFEngine, the applicable Commercial Open Source License
+##  (COSL) may apply to this file if you as a licensee so wish it. See
+##  included file COSL.txt.
+############################################################################
+
+# This file contains code from CFEngine's files stdlib only compatible with CFEngine < 3.9
+# @agent_version <3.9
+
+body select_region INI_section(x)
+{
+  select_start => "\[$(x)\]\s*";
+  select_end => "\[.*\]\s*";
+}
+

--- a/tree/20_cfe_basics/cfengine/files.39p.cf
+++ b/tree/20_cfe_basics/cfengine/files.39p.cf
@@ -1,0 +1,29 @@
+############################################################################
+###  Copyright (C) CFEngine AS
+###
+###  This program is free software; you can redistribute it and/or modify it
+###  under the terms of the GNU Lesser General Public License LGPL as published by the
+###  Free Software Foundation; version 3.
+###
+###  This program is distributed in the hope that it will be useful,
+###  but WITHOUT ANY WARRANTY; without even the implied warranty of
+###  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+###  GNU General Public License for more details.
+###
+###  To the extent this program is licensed as part of the Enterprise
+###  versions of CFEngine, the applicable Commercial Open Source License
+###  (COSL) may apply to this file if you as a licensee so wish it. See
+###  included file COSL.txt.
+#############################################################################
+#
+# This file contains code from CFEngine's files stdlib only compatible with CFEngine >= 3.9
+# @agent_version >=3.9
+
+body select_region INI_section(x)
+{
+  select_start => "\[$(x)\]\s*";
+  select_end => "\[.*\]\s*";
+# Allow End of File to be considered as end of region if pattern not found
+  select_end_match_eof => "true";
+}
+

--- a/tree/20_cfe_basics/cfengine/files.cf
+++ b/tree/20_cfe_basics/cfengine/files.cf
@@ -746,13 +746,8 @@ replace_value => "$(x)";
 occurrences => "all";
 }
 
-##
 
-body select_region INI_section(x)
-{
-select_start => "\[$(x)\]\s*";
-select_end => "\[.*\]\s*";
-}
+# INI_section has been moved into version-specific files, files_39p.cf and files_39m.cf
 
 ##-------------------------------------------------------
 ## edit_defaults


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8638