### PR TITLE
Fixes #9096: rudderification breaks when a parameter contains '&'

### DIFF
--- a/tools/ncf_rudder.py
+++ b/tools/ncf_rudder.py
@@ -320,6 +320,7 @@ def generate_rudder_reporting(technique):
 
     class_prefix = generic_method["class_prefix"]+"_"+key_value_canonified
     logger_rudder_call = '"dummy_report" usebundle => logger_rudder("' + generic_method['name'] + ' ' + key_value + ' if ' + method_call['class_context'] + '", "' + class_prefix +'")'
+    logger_rudder_call = logger_rudder_call.replace("&", "\\&")
 
     # Always add an empty line for readability
     content.append('')


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9096

Replacing previous PR: https://github.com/Normation/ncf/pull/450
