### PR TITLE
Fixes #8021: ncf Editor renders buttons outside of visible range if long content.

### DIFF
--- a/builder/css/custom.css
+++ b/builder/css/custom.css
@@ -326,6 +326,7 @@ ul[dnd-list] {
 .method-param {
   font-size: 16px;
   margin: 0;
+  word-break: break-word;
 }
 
 .method-settings{


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8021