### PR TITLE
Fixes #9791: test -e doesn't exist on Solaris, script list-compatible-inputs needs some tweaks

### DIFF
--- a/tree/10_ncf_internals/list-compatible-inputs
+++ b/tree/10_ncf_internals/list-compatible-inputs
@@ -60,7 +60,7 @@ fi
 
 # list capabilities
 capabilities=""
-if [ -e "${capability_file}" ]
+if [ -f "${capability_file}" ]
 then
   capabilities=`cat "${capability_file}"`
 else


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9791