### PR TITLE
Fixes #10018: Inconsistent use of tabs and spaces in apt_get module

### DIFF
--- a/tree/10_ncf_internals/modules/packages/apt_get
+++ b/tree/10_ncf_internals/modules/packages/apt_get
@@ -202,8 +202,8 @@ def list_updates(online):
 def get_platform_arch():
     process = subprocess_Popen([dpkg_cmd, "--print-architecture"], stdout=subprocess.PIPE)
     for line in process.stdout:
-	if PY3:
-	    line = line.decode("utf-8")
+        if PY3:
+            line = line.decode("utf-8")
         return line.rstrip()
     return None
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10018