### PR TITLE
Fixes #10153: Calling twice file_ensure_key_value_present_in_ini_section for same file and section doesn't do anything for the second call

### DIFF
--- a/tests/acceptance/30_generic_methods/file_ensure_key_value_present_in_ini_section_twice_edit.cf
+++ b/tests/acceptance/30_generic_methods/file_ensure_key_value_present_in_ini_section_twice_edit.cf
@@ -1,0 +1,87 @@
+#######################################################
+#
+# Test checking if a keng twice in a section does effectively edit twice
+#
+#######################################################
+
+bundle common acc_path
+{
+  vars:
+    "root" string => getenv("NCF_TESTS_ACCEPTANCE", 1024);
+}
+
+body common control
+{
+      inputs => { "${acc_path.root}/default.cf.sub", "${acc_path.root}/default_ncf.cf.sub", "@{ncf_inputs.default_files}" };
+      bundlesequence  => { default("${this.promise_filename}") };
+      version => "1.0";
+}
+
+#######################################################
+bundle agent init
+{
+  vars:
+    "tmp"             string => getenv("TEMP", 1024);
+    "file_1"            string => "${tmp}/test1.ini";
+    "reference_file_1"  string => "${tmp}/ref1.ini";
+    "file_1_canon"      string => canonify("${file_1}");
+
+# Ensure that double edition within a section succeed
+    "section_1"         string => "section_test1";
+    "name_1"            string => "name";
+    "value_1"           string => "value";
+    "name_2"            string => "key";
+    "value_2"           string => "value";
+
+    "base_text_up"      string => "[section_test1]";
+    "base_text_down"    string => "[section_test2]";
+    "reference_1"       string => "${base_text_up}
+${name_1}=${value_1}
+${name_2}=${value_2}
+${base_text_down}";
+
+
+  commands:
+# Initialize first test files
+    "/bin/echo"
+      args    => "\"${reference_1}\" > \"${reference_file_1}\"",
+      contain => in_shell;
+   "/bin/echo"
+      args    => "\"${base_text_up}\" > \"${file_1}\"",
+      contain => in_shell;
+   "/bin/echo"
+      args    => "\"${base_text_down}\" >> \"${file_1}\"",
+      contain => in_shell;
+}
+
+#######################################################
+
+bundle agent test
+{
+  methods:
+    "ph1" usebundle => file_ensure_key_value_present_in_ini_section("${init.file_1}", "${init.section_1}", "${init.name_1}", "${init.value_1}");
+    "ph2" usebundle => file_ensure_key_value_present_in_ini_section("${init.file_1}", "${init.section_1}", "${init.name_2}", "${init.value_2}");
+}
+
+#######################################################
+
+bundle agent check
+{
+  vars:
+    # Commands to check that reference files (expected result) are the same
+    # than the modified files by the generic_method 'file_ensure_key_value_present_in_ini_section'
+    "file_correct_test" string => "/usr/bin/diff \"${init.reference_file_1}\" \"${init.file_1}\"";
+
+  classes:
+    "file_correct"
+       expression => returnszero("${file_correct_test}", "noshell"),
+       ifvarclass => canonify("file_ensure_key_value_present_in_ini_section_${init.file_1}_reached");
+    "ok"    expression => "file_correct.file_ensure_key_value_present_in_ini_section_${init.file_1_canon}_ok.!file_1_ensure_line_present_in_ini_section_${init.file_1_canon}_error";
+
+  reports:
+    ok::
+      "$(this.promise_filename) Pass";
+    !ok::
+      "$(this.promise_filename) FAIL";
+}
+

--- a/tree/30_generic_methods/file_ensure_key_value_present_in_ini_section.cf
+++ b/tree/30_generic_methods/file_ensure_key_value_present_in_ini_section.cf
@@ -38,7 +38,8 @@ bundle agent file_ensure_key_value_present_in_ini_section(file, section, name, v
         create        => "true",
         edit_line     => set_variable_values_ini("file_ensure_key_value_present_in_ini_section.content", "${section}"),
         edit_defaults => ncf_empty_select("false"),
-        classes       => classes_generic("${class_prefix}");
+        classes       => classes_generic("${class_prefix}"),
+        comment       => "Editing file ${file} to set ${name} = ${value} in section ${section}";
 
   methods:
       "sanitize" usebundle => _classes_sanitize("${class_prefix}");


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10153