### PR TITLE
Fixes #10575: putting a double quote in a technique in the "class" parameter generate an invalid rudder-reporting file for the agent

### DIFF
--- a/tests/unit/test_expected_reports.csv
+++ b/tests/unit/test_expected_reports.csv
@@ -3,3 +3,4 @@
 bla;;package_install_${bla.apache_package_name};;@@RUDDER_ID@@;;Package install version;;${bla.apache_package_name}
 bla;;service_start_${bla.apache_package_name};;@@RUDDER_ID@@;;Service start;;${bla.apache_package_name}
 bla;;package_install_openssh-server;;@@RUDDER_ID@@;;Package install;;openssh-server
+bla;;command_execution_/bin/echo "test";;@@RUDDER_ID@@;;Command execution;;/bin/echo "test"

--- a/tests/unit/test_metadata.xml
+++ b/tests/unit/test_metadata.xml
@@ -4,6 +4,11 @@
     <NAME>bla</NAME>
   </BUNDLES>
   <SECTIONS>
+    <SECTION component="true" multivalued="true" name="Command execution">
+      <REPORTKEYS>
+        <VALUE><![CDATA[/bin/echo "test"]]></VALUE>
+      </REPORTKEYS>
+    </SECTION>
     <SECTION component="true" multivalued="true" name="Package install">
       <REPORTKEYS>
         <VALUE><![CDATA[openssh-server]]></VALUE>

--- a/tests/unit/test_ncf_rudder.py
+++ b/tests/unit/test_ncf_rudder.py
@@ -51,6 +51,11 @@ class TestNcfRudder(unittest.TestCase):
     with open(self.test_metadata_xml_file) as fd:
       self.test_metadata_xml_content = fd.read()
 
+    self.test_rudder_reporting_file = os.path.realpath('test_technique_rudder_reporting.cf')
+    with open(self.test_rudder_reporting_file) as fd:
+      self.test_rudder_reporting_content = fd.read()
+
+
   def test_expected_reports_from_technique(self):
     expected_reports_string = ncf_rudder.get_technique_expected_reports(self.technique_metadata)
     self.assertEqual(expected_reports_string, self.test_expected_reports_csv_content)
@@ -60,6 +65,13 @@ class TestNcfRudder(unittest.TestCase):
     metadata_xml_string = ncf_rudder.get_technique_metadata_xml(self.technique_metadata)
     expected_metadata_pure_xml = self.test_metadata_xml_content
     self.assertEqual(expected_metadata_pure_xml, metadata_xml_string)
+
+  def test_rudder_reporting_from_technique(self):
+    """The rudder-reporting.cf content generated from a ncf technique must match the reporting we expect for our technique"""
+    rudder_reporting_string = ncf_rudder.generate_rudder_reporting(self.technique_metadata)
+    expected_rudder_reporting = self.test_rudder_reporting_content
+    self.assertEqual(expected_rudder_reporting, rudder_reporting_string)
+
 
   def test_path_for_technique_dir(self):
     root_path = '/tmp/ncf_rudder_tests'

--- a/tests/unit/test_technique.cf
+++ b/tests/unit/test_technique.cf
@@ -24,8 +24,9 @@ bundle agent bla {
     cfengine::
       "ph2" usebundle => service_start("${bla.apache_package_name}");
       "ph3" usebundle => package_install("openssh-server");
+      "ph4" usebundle => command_execution("/bin/echo \"test\"");
     !cfengine::
-      "ph4" usebundle => _logger("NA", "NA");
+      "ph5" usebundle => _logger("NA", "NA");
 
 
 }

--- a/tests/unit/test_technique_rudder_reporting.cf
+++ b/tests/unit/test_technique_rudder_reporting.cf
@@ -1,0 +1,16 @@
+bundle agent bla_rudder_reporting
+{
+  methods:
+
+    !(cfengine)::
+      "dummy_report" usebundle => _classes_noop("service_start_${bla.apache_package_name}");
+      "dummy_report" usebundle => logger_rudder("Service start ${bla.apache_package_name} if cfengine", "service_start_${bla.apache_package_name}");
+
+    !(cfengine)::
+      "dummy_report" usebundle => _classes_noop("package_install_openssh_server");
+      "dummy_report" usebundle => logger_rudder("Package install openssh-server if cfengine", "package_install_openssh_server");
+
+    !(cfengine)::
+      "dummy_report" usebundle => _classes_noop("command_execution__bin_echo__test_");
+      "dummy_report" usebundle => logger_rudder("Command execution /bin/echo \"test\" if cfengine", "command_execution__bin_echo__test_");
+}

--- a/tools/ncf_rudder.py
+++ b/tools/ncf_rudder.py
@@ -308,18 +308,26 @@ def generate_rudder_reporting(technique):
   for method_call in filter_calls:
 
     method_name = method_call['method_name']
+    if method_call['method_name'].startswith("_"):
+      continue
     generic_method = generic_methods[method_name]
 
     key_value = method_call["args"][generic_method["class_parameter_id"]-1]
-    # this regex allows to canonify everything except variables
-    regex = re.compile("[^\$\{\}a-zA-Z0-9_](?![^{}]+})|\$(?!{)")
     # to match cfengine behaviour we need to treat utf8 as if it was ascii (see #7195)
     # string should be unicode string (ie u'') which is the case if they are read from files opened with encoding="utf-8"
     key_value = key_value.encode("utf-8").decode("iso-8859-1") 
+
+    # this regex allows to canonify everything except variables
+    regex = re.compile("[^\$\{\}a-zA-Z0-9_](?![^{}]+})|\$(?!{)")
     key_value_canonified = regex.sub("_", key_value)
 
+    # escape double quote
+    regex_quote = re.compile(r'(?<!\\)"', flags=re.UNICODE )
+    escaped_key_value = regex_quote.sub('\\"', key_value)
+
+
     class_prefix = generic_method["class_prefix"]+"_"+key_value_canonified
-    logger_rudder_call = '"dummy_report" usebundle => logger_rudder("' + generic_method['name'] + ' ' + key_value + ' if ' + method_call['class_context'] + '", "' + class_prefix +'")'
+    logger_rudder_call = '"dummy_report" usebundle => logger_rudder("' + generic_method['name'] + ' ' + escaped_key_value + ' if ' + method_call['class_context'] + '", "' + class_prefix +'")'
     logger_rudder_call = logger_rudder_call.replace("&", "\\&")
 
     # Always add an empty line for readability


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10575