### PR TITLE
Fixes #11281: Removing trailing spaces from generic methods metadata

### DIFF
--- a/tools/ncf.py
+++ b/tools/ncf.py
@@ -157,7 +157,7 @@ def parse_bundlefile_metadata(content, bundle_type):
     #unicodeLine = unicode(line,"UTF-8") #line.decode('unicode-escape')
 
     # Parse metadata tag line
-    match = re.match("^\s*#\s*@(\w+)\s+(([a-zA-Z0-9_]+)\s+(.*)|.*)$", line, flags=re.UNICODE)
+    match = re.match("^\s*#\s*@(\w+)\s+(([a-zA-Z0-9_]+)\s+(.*?)|.*?)\s*$", line, flags=re.UNICODE)
     if match :
       tag = match.group(1)
       # Check if we are a valid tag


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11281