### PR TITLE
Fixes #11870: rudder_reporting file is invalid on nodes if it contains '&&' in one of its parameter

### DIFF
--- a/tests/unit/test_ncf_rudder.py
+++ b/tests/unit/test_ncf_rudder.py
@@ -93,13 +93,13 @@ class TestNcfRudder(unittest.TestCase):
   def test_rudder_reporting_file(self):
     root_path = '/tmp/ncf_rudder_tests_reporting'
     ncf_rudder.write_technique_for_rudder(root_path, self.reporting_metadata)
-    result = os.path.exists(os.path.realpath(os.path.join(root_path, 'bla', '0.1', "rudder_reporting.st")))
+    result = os.path.exists(os.path.realpath(os.path.join(root_path, 'bla', '0.1', "rudder_reporting.cf")))
     self.assertTrue(result)
 
   def test_any_technique_reporting_file(self):
     root_path = '/tmp/ncf_rudder_tests_any'
     ncf_rudder.write_technique_for_rudder(root_path, self.any_technique_metadata)
-    result = not os.path.exists(os.path.realpath(os.path.join(root_path, 'bla', '0.1', "rudder_reporting.st")))
+    result = not os.path.exists(os.path.realpath(os.path.join(root_path, 'bla', '0.1', "rudder_reporting.cf")))
     self.assertTrue(result)
 
 

--- a/tools/ncf_rudder.py
+++ b/tools/ncf_rudder.py
@@ -153,7 +153,7 @@ def write_expected_reports_file(path,technique):
 
 def write_rudder_reporting_file(path,technique):
   """ write rudder_reporting.st file from a technique, to a path """
-  file = codecs.open(os.path.realpath(os.path.join(path, "rudder_reporting.st")), "w", encoding="utf-8")
+  file = codecs.open(os.path.realpath(os.path.join(path, "rudder_reporting.cf")), "w", encoding="utf-8")
   content = generate_rudder_reporting(technique)
   file.write(content)
   file.close()
@@ -182,15 +182,14 @@ def get_technique_metadata_xml(technique_metadata, include_rudder_reporting = Fa
     content.append('    <NAME>'+ technique_metadata['bundle_name'] + '_rudder_reporting</NAME>')
   content.append('  </BUNDLES>')
 
-  if include_rudder_reporting:
-    content.append('  <TMLS>')
-    content.append('    <TML name="rudder_reporting"/>')
-    content.append('  </TMLS>')
-
   content.append('  <FILES>')
   content.append('    <FILE name="RUDDER_CONFIGURATION_REPOSITORY/ncf/50_techniques/'+technique_metadata['bundle_name']+'/'+technique_metadata['bundle_name']+'.cf">')
   content.append('      <INCLUDED>true</INCLUDED>')
   content.append('    </FILE>')
+  if include_rudder_reporting:
+    content.append('    <FILE name="RUDDER_CONFIGURATION_REPOSITORY/techniques/ncf_techniques/'+technique_metadata['bundle_name']+'/'+technique_metadata['version']+'rudder_reporting.cf">')
+    content.append('      <INCLUDED>true</INCLUDED>')
+    content.append('    </FILE>')
   content.append('  </FILES>')
 
   content.append('  <SECTIONS>')


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11870