### PR TITLE
Fixes #11879: Rename some generic methods to match our naming convention

### DIFF
--- a/tests/acceptance/30_generic_methods/file_absent.cf
+++ b/tests/acceptance/30_generic_methods/file_absent.cf
@@ -1,6 +1,6 @@
 #######################################################
 #
-# Test checking that file_remove removes a file
+# Test checking that file_absent removes a file
 #
 #######################################################
 
@@ -39,8 +39,8 @@ bundle agent init
 bundle agent test
 {
   methods:
-    "ph1" usebundle => file_remove("${init.destination_file}");
-    "ph2" usebundle => file_remove("${init.not_a_file}");
+    "ph1" usebundle => file_absent("${init.destination_file}");
+    "ph2" usebundle => file_absent("${init.not_a_file}");
 }
 
 #######################################################
@@ -49,8 +49,8 @@ bundle agent check
 {
   classes:
     "file_exists"      expression => fileexists("${init.destination_file}");
-    "ok_1"             expression => "!file_exists.file_remove_${init.destination_file_canon}_repaired.!file_remove_${init.destination_file_canon}_error";
-    "ok_2"             expression => "file_remove_${init.not_a_file_canon}_kept.!file_remove_${init.not_a_file_canon}_repaired.!file_remove_${init.not_a_file_canon}_error";
+    "ok_1"             expression => "!file_exists.file_absent_${init.destination_file_canon}_repaired.!file_absent_${init.destination_file_canon}_error";
+    "ok_2"             expression => "file_absent_${init.not_a_file_canon}_kept.!file_absent_${init.not_a_file_canon}_repaired.!file_absent_${init.not_a_file_canon}_error";
     "ok"                      and => { "ok_1", "ok_2" };
 
   reports:
@@ -62,10 +62,10 @@ bundle agent check
     !ok_2:: "Second test failed (removing a non existant file, ${init.not_a_file_canon})";
 
     !ok_2:: #debug
-      "Second test debug: class file_remove_${init.not_a_file_canon}_reached defined" ifvarclass => "file_remove_${init.not_a_file_canon}_reached";
-      "Second test debug: class file_remove_${init.not_a_file_canon}_kept defined" ifvarclass => "file_remove_${init.not_a_file_canon}_kept";
-      "Second test debug: class file_remove_${init.not_a_file_canon}_repaired defined" ifvarclass => "file_remove_${init.not_a_file_canon}_repaired";
-      "Second test debug: class file_remove_${init.not_a_file_canon}_error defined" ifvarclass => "file_remove_${init.not_a_file_canon}_error";
+      "Second test debug: class file_absent_${init.not_a_file_canon}_reached defined" ifvarclass => "file_absent_${init.not_a_file_canon}_reached";
+      "Second test debug: class file_absent_${init.not_a_file_canon}_kept defined" ifvarclass => "file_absent_${init.not_a_file_canon}_kept";
+      "Second test debug: class file_absent_${init.not_a_file_canon}_repaired defined" ifvarclass => "file_absent_${init.not_a_file_canon}_repaired";
+      "Second test debug: class file_absent_${init.not_a_file_canon}_error defined" ifvarclass => "file_absent_${init.not_a_file_canon}_error";
 
     ok::
       "$(this.promise_filename) Pass";

--- a/tests/acceptance/30_generic_methods/permissions_dirs_recursive.cf
+++ b/tests/acceptance/30_generic_methods/permissions_dirs_recursive.cf
@@ -34,11 +34,11 @@ bundle agent init
       create => "true",
       perms  => mog("000", "root", "0");
 
-    "${directory}/file1"
+    "${directory}/file1/."
       create => "true",
       perms  => mog("000", "root", "0");
 
-    "${directory}/file2"
+    "${directory}/file2/."
       create => "true",
       perms  => mog("000", "root", "0");
 
@@ -49,7 +49,7 @@ bundle agent init
 bundle agent test
 {
   methods:
-    "ph1" usebundle => permissions_recurse("${init.directory}", "${init.mode}", "${init.owner}", "${init.group}");
+    "ph1" usebundle => permissions_dirs_recursive("${init.directory}", "${init.mode}", "${init.owner}", "${init.group}");
 }
 
 #######################################################

--- a/tests/acceptance/30_generic_methods/permissions_recursive.cf
+++ b/tests/acceptance/30_generic_methods/permissions_recursive.cf
@@ -34,11 +34,11 @@ bundle agent init
       create => "true",
       perms  => mog("000", "root", "0");
 
-    "${directory}/file1/."
+    "${directory}/file1"
       create => "true",
       perms  => mog("000", "root", "0");
 
-    "${directory}/file2/."
+    "${directory}/file2"
       create => "true",
       perms  => mog("000", "root", "0");
 
@@ -49,7 +49,7 @@ bundle agent init
 bundle agent test
 {
   methods:
-    "ph1" usebundle => permissions_dirs_recurse("${init.directory}", "${init.mode}", "${init.owner}", "${init.group}");
+    "ph1" usebundle => permissions_recursive("${init.directory}", "${init.mode}", "${init.owner}", "${init.group}");
 }
 
 #######################################################

--- a/tests/acceptance/30_generic_methods/unsafe/service_disabled.cf
+++ b/tests/acceptance/30_generic_methods/unsafe/service_disabled.cf
@@ -1,6 +1,6 @@
 #######################################################
 #
-# Test if cf-serverd is started and if no, start it
+# Disable cron at boot, also try with an unkown service to test error case
 #
 #######################################################
 
@@ -22,17 +22,8 @@ body common control
 bundle agent init
 {
   vars:
-    debian::
-      "service_name"  string => "ssh";
-    redhat::
-      "service_name"  string => "sshd";
-    any::
-      # here we don't use the full path to support multiple version of agent
-      # plus, the check on the path is not anchored, ensuring that it will
-      # find the right process
-      "service_path"  string => "/sbin/sshd";
-      "cservice_name" string => canonify("${service_name}");
-      "cservice_path" string => canonify("${service_path}");
+    "service_name"  string => "cron";
+    "unknown_service_name" string => "unknown";
 }
 
 #######################################################
@@ -40,7 +31,8 @@ bundle agent init
 bundle agent test
 {
   methods:
-    "ph1" usebundle => service_ensure_running_path("${init.service_name}", "${init.service_path}");
+    "ph1" usebundle => service_disabled("${init.service_name}");
+    "ph2" usebundle => service_disabled("${init.unknown_service_name}");
 }
 
 #######################################################
@@ -48,7 +40,7 @@ bundle agent test
 bundle agent check
 {
   classes:
-    "ok" expression => "service_ensure_running_${init.cservice_name}_ok.!service_ensure_running_${init.cservice_name}_error";
+    "ok" expression => "service_disabled_${init.service_name}_ok.!service_disabled_${init.service_name}_error";
 
   reports:
     ok::

--- a/tests/acceptance/30_generic_methods/unsafe/service_started.cf
+++ b/tests/acceptance/30_generic_methods/unsafe/service_started.cf
@@ -1,7 +1,6 @@
 #######################################################
 #
-# Manually stop service, start it using ncf and check 
-# if it's been started
+# Test if cron is started and if no, start it
 #
 #######################################################
 
@@ -23,13 +22,12 @@ body common control
 bundle agent init
 {
   vars:
-    !aix::
+    debian::
       "service_name"  string => "cron";
+    redhat::
+      "service_name"  string => "crond";
     aix::
       "service_name"  string => "syslogd";
-
-  commands:
-    "/usr/sbin/service ${service_name} stop";
 }
 
 #######################################################
@@ -37,28 +35,19 @@ bundle agent init
 bundle agent test
 {
   methods:
-    "ph1" usebundle => service_ensure_running("${init.service_name}");
+    "ph1" usebundle => service_started("${init.service_name}");
 }
 
 #######################################################
 
 bundle agent check
 {
-  vars:
-    "command_ps" string => "/bin/ps afux | /bin/grep ${init.service_name} | /bin/grep -v grep";
-
   classes:
-      "service_running" expression => returnszero("${command_ps}", "useshell"),
-                        ifvarclass => "service_ensure_running_${init.service_name}_reached";
-
-      "ok"              expression => "service_running.(service_ensure_running_${init.service_name}_repaired.!service_ensure_running_${init.service_name}_error)";
+    "ok" expression => "service_started_${init.service_name}_ok.!service_started_${init.service_name}_error";
 
   reports:
     ok::
       "$(this.promise_filename) Pass";
     !ok::
       "$(this.promise_filename) FAIL";
-    !service_running::
-      "Service ${init.service_name} was not detected as running using ${command_ps} command";
-
 }

--- a/tests/acceptance/30_generic_methods/unsafe/service_started_path.cf
+++ b/tests/acceptance/30_generic_methods/unsafe/service_started_path.cf
@@ -1,6 +1,6 @@
 #######################################################
 #
-# Test if cron is started and if no, start it
+# Test if cf-serverd is started and if no, start it
 #
 #######################################################
 
@@ -23,11 +23,16 @@ bundle agent init
 {
   vars:
     debian::
-      "service_name"  string => "cron";
+      "service_name"  string => "ssh";
     redhat::
-      "service_name"  string => "crond";
-    aix::
-      "service_name"  string => "syslogd";
+      "service_name"  string => "sshd";
+    any::
+      # here we don't use the full path to support multiple version of agent
+      # plus, the check on the path is not anchored, ensuring that it will
+      # find the right process
+      "service_path"  string => "/sbin/sshd";
+      "cservice_name" string => canonify("${service_name}");
+      "cservice_path" string => canonify("${service_path}");
 }
 
 #######################################################
@@ -35,7 +40,7 @@ bundle agent init
 bundle agent test
 {
   methods:
-    "ph1" usebundle => service_ensure_running("${init.service_name}");
+    "ph1" usebundle => service_started_path("${init.service_name}", "${init.service_path}");
 }
 
 #######################################################
@@ -43,7 +48,7 @@ bundle agent test
 bundle agent check
 {
   classes:
-    "ok" expression => "service_ensure_running_${init.service_name}_ok.!service_ensure_running_${init.service_name}_error";
+    "ok" expression => "service_started_${init.cservice_name}_ok.!service_started_${init.cservice_name}_error";
 
   reports:
     ok::

--- a/tests/acceptance/30_generic_methods/unsafe/service_started_start.cf
+++ b/tests/acceptance/30_generic_methods/unsafe/service_started_start.cf
@@ -1,6 +1,7 @@
 #######################################################
 #
-# Disable cron at boot, also try with an unkown service to test error case
+# Manually stop service, start it using ncf and check 
+# if it's been started
 #
 #######################################################
 
@@ -22,8 +23,13 @@ body common control
 bundle agent init
 {
   vars:
-    "service_name"  string => "cron";
-    "unknown_service_name" string => "unknown";
+    !aix::
+      "service_name"  string => "cron";
+    aix::
+      "service_name"  string => "syslogd";
+
+  commands:
+    "/usr/sbin/service ${service_name} stop";
 }
 
 #######################################################
@@ -31,20 +37,28 @@ bundle agent init
 bundle agent test
 {
   methods:
-    "ph1" usebundle => service_ensure_disabled_at_boot("${init.service_name}");
-    "ph2" usebundle => service_ensure_disabled_at_boot("${init.unknown_service_name}");
+    "ph1" usebundle => service_started("${init.service_name}");
 }
 
 #######################################################
 
 bundle agent check
 {
+  vars:
+    "command_ps" string => "/bin/ps afux | /bin/grep ${init.service_name} | /bin/grep -v grep";
+
   classes:
-    "ok" expression => "service_ensure_disabled_at_boot_${init.service_name}_ok.!service_ensure_disabled_at_boot_${init.service_name}_error";
+      "service_running" expression => returnszero("${command_ps}", "useshell"),
+                        ifvarclass => "service_started_${init.service_name}_reached";
+
+      "ok"              expression => "service_running.(service_started_${init.service_name}_repaired.!service_started_${init.service_name}_error)";
 
   reports:
     ok::
       "$(this.promise_filename) Pass";
     !ok::
       "$(this.promise_filename) FAIL";
+    !service_running::
+      "Service ${init.service_name} was not detected as running using ${command_ps} command";
+
 }

--- a/tests/acceptance/30_generic_methods/unsafe/service_stopped.cf
+++ b/tests/acceptance/30_generic_methods/unsafe/service_stopped.cf
@@ -30,7 +30,7 @@ bundle agent init
 bundle agent test
 {
   methods:
-    "ph1" usebundle => service_ensure_stopped("${init.service_name}");
+    "ph1" usebundle => service_stopped("${init.service_name}");
 }
 
 #######################################################
@@ -38,7 +38,7 @@ bundle agent test
 bundle agent check
 {
   classes:
-    "ok" expression => "service_ensure_stopped_${init.service_name}_ok.!service_ensure_stopped_${init.service_name}_error";
+    "ok" expression => "service_stopped_${init.service_name}_ok.!service_stopped_${init.service_name}_error";
 
   reports:
     ok::

--- a/tree/30_generic_methods/directory_present.cf
+++ b/tree/30_generic_methods/directory_present.cf
@@ -1,5 +1,5 @@
 #####################################################################################
-# Copyright 2014 Normation SAS
+# Copyright 2017 Normation SAS
 #####################################################################################
 #
 # This program is free software: you can redistribute it and/or modify
@@ -16,32 +16,27 @@
 #
 #####################################################################################
 
-# @name Directory create
+# @name Directory present
 # @description Create a directory if it doesn't exist
-# @rename directory_present
-# @deprecated Use [directory_present](#directory_present) instead.
 #
 # @parameter target Full path of directory to create (trailing '/' is optional)
 #
-# @class_prefix directory_create
+# @class_prefix directory_present
 # @class_parameter target
 
-bundle agent directory_create(target)
+bundle agent directory_present(target)
 {
   vars:
-    "canonified_target"    string => canonify("${target}");
-
-    "old_class_prefix" string => canonify("directory_create_${target}");
+    "old_class_prefix" string => canonify("directory_present_${target}");
     "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
     "class_prefix"      string => canonify(join("_", "promisers"));
     "args"              slist => { "${target}" };
 
+  files:
+    "${target}/."
+      create        => "true",
+      classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
+
   methods:
-    "action"             usebundle => directory_present("${target}");
-    "class copy"         usebundle => _classes_copy("directory_present_${canonified_target}", "${old_class_prefix}"),
-                         ifvarclass => "directory_present_${canonified_target}_reached";
-    "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
-                         ifvarclass => "${class_prefix}_action_reached";
     "report"             usebundle => _log("Create directory ${target}", "${old_class_prefix}", "${class_prefix}", @{args});
 }
-

--- a/tree/30_generic_methods/file_absent.cf
+++ b/tree/30_generic_methods/file_absent.cf
@@ -1,5 +1,5 @@
 #####################################################################################
-# Copyright 2014 Normation SAS
+# Copyright 2017 Normation SAS
 #####################################################################################
 #
 # This program is free software: you can redistribute it and/or modify
@@ -16,32 +16,34 @@
 #
 #####################################################################################
 
-# @name Directory create
-# @description Create a directory if it doesn't exist
-# @rename directory_present
-# @deprecated Use [directory_present](#directory_present) instead.
+# @name File absent
+# @description Remove a file if it exists
 #
-# @parameter target Full path of directory to create (trailing '/' is optional)
+# @parameter target     File to remove (absolute path on the target node)
 #
-# @class_prefix directory_create
+# @class_prefix file_absent
 # @class_parameter target
 
-bundle agent directory_create(target)
+bundle agent file_absent(target)
 {
   vars:
-    "canonified_target"    string => canonify("${target}");
-
-    "old_class_prefix" string => canonify("directory_create_${target}");
+    "old_class_prefix" string => canonify("file_absent_${target}");
     "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
     "class_prefix"      string => canonify(join("_", "promisers"));
     "args"              slist => { "${target}" };
 
-  methods:
-    "action"             usebundle => directory_present("${target}");
-    "class copy"         usebundle => _classes_copy("directory_present_${canonified_target}", "${old_class_prefix}"),
-                         ifvarclass => "directory_present_${canonified_target}_reached";
-    "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
-                         ifvarclass => "${class_prefix}_action_reached";
-    "report"             usebundle => _log("Create directory ${target}", "${old_class_prefix}", "${class_prefix}", @{args});
-}
+  files:
+    "${target}"
+      delete        => tidy,
+      classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
+  methods:
+    "success_if_nothing" usebundle => _classes_success("${old_class_prefix}"),
+                         ifvarclass => "!${old_class_prefix}_reached";
+
+    "success_if_nothing" usebundle => _classes_success("${class_prefix}"),
+                         ifvarclass => "has_promiser_stack.!${class_prefix}_reached";
+
+    "report"             usebundle => _log("Remove file ${target}", "${old_class_prefix}", "${class_prefix}", @{args});
+
+}

--- a/tree/30_generic_methods/file_content.cf
+++ b/tree/30_generic_methods/file_content.cf
@@ -1,5 +1,5 @@
 #####################################################################################
-# Copyright 2013 Normation SAS
+# Copyright 2017 Normation SAS
 #####################################################################################
 #
 # This program is free software: you can redistribute it and/or modify
@@ -16,33 +16,33 @@
 #
 #####################################################################################
 
-# @name File enforce content
-# @rename file_content
-# @deprecated Use [file_content](#file_content) instead.
+# @name File content
 # @description Enfore the content of a file
 #
 # @parameter file  File name to edit (absolute path on the target node)
 # @parameter lines Line(s) to add in the file
 # @parameter enforce Enforce the file to contain only line(s) defined (true or false)
 # 
-# @class_prefix file_ensure_lines_present
+# @class_prefix file_content
 # @class_parameter file
 
-bundle agent file_enforce_content(file, lines, enforce)
+bundle agent file_content(file, lines, enforce)
 {
   vars:
-      "canonified_file"    string => canonify("${file}");
-
-      "old_class_prefix" string => canonify("file_ensure_lines_present_${file}");
+      "old_class_prefix" string => canonify("file_content_${file}");
       "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
       "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${file}", "${lines}", "${enforce}" };
 
+  files:
+      "${file}"
+        create        => "true",
+        edit_line     => insert_lines("${lines}"),
+        edit_defaults => ncf_empty_select("${enforce}"),
+        classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
+
   methods:
-    "action"             usebundle => file_content("${target}");
-    "class copy"         usebundle => _classes_copy("file_content_${canonified_file}", "${old_class_prefix}"),
-                         ifvarclass => "file_content_${canonified_file}_reached";
-    "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
-                         ifvarclass => "${class_prefix}_action_reached";
-    "report"             usebundle => _log("Insert content ${lines} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "sanitize" usebundle => _classes_sanitize("${old_class_prefix}");
+      "sanitize" usebundle => _classes_sanitize("${class_prefix}");
+      "report" usebundle => _log("Insert content ${lines} into ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
 }

--- a/tree/30_generic_methods/file_download.cf
+++ b/tree/30_generic_methods/file_download.cf
@@ -18,6 +18,8 @@
 
 # @name File download
 # @description Download a file if it does not exist, using curl with a fallback on wget
+# @rename file_from_http_server
+# @deprecated Use [file_from_http_server](#file_from_http_server) instead.
 # @documentation This method finds a HTTP command-line tool and downloads the given source
 # into the destination.
 # 
@@ -34,54 +36,21 @@ bundle agent file_download(source, destination)
 
   vars:
 
-    _stdlib_path_exists_curl::
-
-      "action_command"            string => "${paths.path[curl]} -s -L -o ${destination} ${source}";
-
-    !_stdlib_path_exists_curl._stdlib_path_exists_wget::
-
-      "action_command"            string => "${paths.path[wget]} -O ${destination} ${source}";
-
     any::
 
       "canonified_destination"    string => canonify("${destination}");
-      "canonified_action_command" string => canonify("${action_command}");
 
       "old_class_prefix"          string => "file_download_${canonified_destination}";
       "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
       "class_prefix"      string => canonify(join("_", "promisers"));
       "args"                       slist => { "${source}", "${destination}" };
 
-  classes:
-
-    "file_exists"    expression => fileexists("${destination}");
-
   methods:
-
-    (_stdlib_path_exists_curl|_stdlib_path_exists_wget).!file_exists::
-
-      "action"                    usebundle => command_execution("${action_command}");
-
-      "class copy"                usebundle => _classes_copy("command_execution_${canonified_action_command}", "${old_class_prefix}");
-
-      "new result classes"        usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}");
-
-      "report"                    usebundle => _log("Download ${source} into ${destination}", "${old_class_prefix}", "${class_prefix}", @{args}),
-                                 ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
-
-    !_stdlib_path_exists_curl.!_stdlib_path_exists_wget.!file_exists::
-
-      "force_failure_class"       usebundle => _classes_failure("${old_class_prefix}");
-      "new result classes"        usebundle => _classes_failure("${class_prefix}");
-      "report"                    usebundle => _log("Unable to download ${source}: neither wget or curl are installed", "${old_class_prefix}", "${class_prefix}", @{args});
-
-    file_exists::
-
-      "force_success_class"       usebundle => _classes_success("${old_class_prefix}"),
-                                 ifvarclass => "!command_execution_${canonified_action_command}_repaired";
-      "new result classes"        usebundle => _classes_success("${class_prefix}"),
-                                 ifvarclass => "!${class_prefix}_action_repaired";
-      "report"                    usebundle => _log("File ${destination} already downloaded", "${old_class_prefix}", "${class_prefix}", @{args}),
-                                 ifvarclass => "(!has_promiser_stack.!command_execution_${canonified_action_command}_repaired)|(has_promiser_stack.!${class_prefix}_action_repaired)";
+    "action"             usebundle => file_from_http_server("${target}");
+    "class copy"         usebundle => _classes_copy("file_from_http_server_${canonified_destination}", "${old_class_prefix}"),
+                         ifvarclass => "file_from_http_server_${canonified_destination}_reached";
+    "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                         ifvarclass => "${class_prefix}_action_reached";
+    "report"             usebundle => _log("Download ${source} into ${destination}", "${old_class_prefix}", "${class_prefix}", @{args});
 
 }

--- a/tree/30_generic_methods/file_from_http_server.cf
+++ b/tree/30_generic_methods/file_from_http_server.cf
@@ -1,0 +1,87 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name File download from HTTP
+# @description Download a file if it does not exist, using curl with a fallback on wget
+# @documentation This method finds a HTTP command-line tool and downloads the given source
+# into the destination.
+# 
+# It tries `curl` first, and `wget` as fallback.
+#
+# @parameter source      URL to download from
+# @parameter destination File destination (absolute path on the target node)
+# 
+# @class_prefix file_from_http_server
+# @class_parameter destination
+
+bundle agent file_from_http_server(source, destination)
+{
+
+  vars:
+
+    _stdlib_path_exists_curl::
+
+      "action_command"            string => "${paths.path[curl]} -s -L -o ${destination} ${source}";
+
+    !_stdlib_path_exists_curl._stdlib_path_exists_wget::
+
+      "action_command"            string => "${paths.path[wget]} -O ${destination} ${source}";
+
+    any::
+
+      "canonified_destination"    string => canonify("${destination}");
+      "canonified_action_command" string => canonify("${action_command}");
+
+      "old_class_prefix"          string => "file_from_http_server_${canonified_destination}";
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
+      "args"                       slist => { "${source}", "${destination}" };
+
+  classes:
+
+    "file_exists"    expression => fileexists("${destination}");
+
+  methods:
+
+    (_stdlib_path_exists_curl|_stdlib_path_exists_wget).!file_exists::
+
+      "action"                    usebundle => command_execution("${action_command}");
+
+      "class copy"                usebundle => _classes_copy("command_execution_${canonified_action_command}", "${old_class_prefix}");
+
+      "new result classes"        usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}");
+
+      "report"                    usebundle => _log("Download ${source} into ${destination}", "${old_class_prefix}", "${class_prefix}", @{args}),
+                                 ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
+
+    !_stdlib_path_exists_curl.!_stdlib_path_exists_wget.!file_exists::
+
+      "force_failure_class"       usebundle => _classes_failure("${old_class_prefix}");
+      "new result classes"        usebundle => _classes_failure("${class_prefix}");
+      "report"                    usebundle => _log("Unable to download ${source}: neither wget or curl are installed", "${old_class_prefix}", "${class_prefix}", @{args});
+
+    file_exists::
+
+      "force_success_class"       usebundle => _classes_success("${old_class_prefix}"),
+                                 ifvarclass => "!command_execution_${canonified_action_command}_repaired";
+      "new result classes"        usebundle => _classes_success("${class_prefix}"),
+                                 ifvarclass => "!${class_prefix}_action_repaired";
+      "report"                    usebundle => _log("File ${destination} already downloaded", "${old_class_prefix}", "${class_prefix}", @{args}),
+                                 ifvarclass => "(!has_promiser_stack.!command_execution_${canonified_action_command}_repaired)|(has_promiser_stack.!${class_prefix}_action_repaired)";
+
+}

--- a/tree/30_generic_methods/file_remove.cf
+++ b/tree/30_generic_methods/file_remove.cf
@@ -18,6 +18,8 @@
 
 # @name File remove
 # @description Remove a file if it exists
+# @rename file_absent
+# @deprecated Use [file_absent](#file_absent) instead.
 #
 # @parameter target     File to remove (absolute path on the target node)
 #
@@ -27,23 +29,18 @@
 bundle agent file_remove(target)
 {
   vars:
+    "canonified_target"    string => canonify("${target}");
+
     "old_class_prefix" string => canonify("file_remove_${target}");
     "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
     "class_prefix"      string => canonify(join("_", "promisers"));
     "args"              slist => { "${target}" };
 
-  files:
-    "${target}"
-      delete        => tidy,
-      classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
-
   methods:
-    "success_if_nothing" usebundle => _classes_success("${old_class_prefix}"),
-                         ifvarclass => "!${old_class_prefix}_reached";
-
-    "success_if_nothing" usebundle => _classes_success("${class_prefix}"),
-                         ifvarclass => "has_promiser_stack.!${class_prefix}_reached";
-
+    "action"             usebundle => directory_present("${target}");
+    "class copy"         usebundle => _classes_copy("file_absent_${canonified_target}", "${old_class_prefix}"),
+                         ifvarclass => "file_absent_${canonified_target}_reached";
+    "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                         ifvarclass => "${class_prefix}_action_reached";
     "report"             usebundle => _log("Remove file ${target}", "${old_class_prefix}", "${class_prefix}", @{args});
-
 }

--- a/tree/30_generic_methods/permissions_dirs_recursive.cf
+++ b/tree/30_generic_methods/permissions_dirs_recursive.cf
@@ -16,9 +16,7 @@
 #
 #####################################################################################
 
-# @name Permissions dirs recurse
-# @rename permissions_dir_recursive
-# @deprecated Use [permissions_dirs_recursive](#permissions_dirs_recursive) instead.
+# @name Permissions dirs recursive
 # @description Verify if a directory has the right permissions recursively
 #
 # @parameter path Path to the directory
@@ -29,7 +27,7 @@
 # @class_prefix permissions
 # @class_parameter path
 
-bundle agent permissions_dirs_recurse(path, mode, owner, group)
+bundle agent permissions_dirs_recursive(path, mode, owner, group)
 {
   vars:
       "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";

--- a/tree/30_generic_methods/permissions_recurse.cf
+++ b/tree/30_generic_methods/permissions_recurse.cf
@@ -16,7 +16,9 @@
 #
 #####################################################################################
 
-# @name Permissions (recursive)
+# @name Permissions (recurse)
+# @rename permissions_recursive
+# @deprecated Use [permissions_recursive](#permissions_recursive) instead.
 # @description Verify if a file or directory has the right permissions recursively
 #
 # @parameter path  Path to the file / directory

--- a/tree/30_generic_methods/permissions_recursive.cf
+++ b/tree/30_generic_methods/permissions_recursive.cf
@@ -16,28 +16,26 @@
 #
 #####################################################################################
 
-# @name Permissions dirs recurse
-# @rename permissions_dir_recursive
-# @deprecated Use [permissions_dirs_recursive](#permissions_dirs_recursive) instead.
-# @description Verify if a directory has the right permissions recursively
+# @name Permissions (recursive)
+# @description Verify if a file or directory has the right permissions recursively
 #
-# @parameter path Path to the directory
-# @parameter mode Mode to enforce
+# @parameter path  Path to the file / directory
+# @parameter mode  Mode to enforce
 # @parameter owner Owner to enforce
 # @parameter group Group to enforce
 #
 # @class_prefix permissions
 # @class_parameter path
 
-bundle agent permissions_dirs_recurse(path, mode, owner, group)
+bundle agent permissions_recursive(path, mode, owner, group)
 {
   vars:
       "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
       "class_prefix"      string => canonify(join("_", "promisers"));
-      "args"              slist => { "${path}", "${mode}", "${owner}", "${group}" };
+      "args"               slist => { "${path}", "${mode}", "${owner}", "${group}" };
 
   methods:
-      "permission with recursion"  usebundle => permissions_type_recursion("${path}", "${mode}", "${owner}", "${group}", "directories", "inf");
+      "permission with recursion"  usebundle => permissions_type_recursion("${path}", "${mode}", "${owner}", "${group}", "all", "inf");
       "new result classes"         usebundle => _classes_copy("${class_prefix}_permission_with_recursion", "${class_prefix}");
 
       "report"                     usebundle => _log("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path}", "", "${class_prefix}", @{args});

--- a/tree/30_generic_methods/service_disabled.cf
+++ b/tree/30_generic_methods/service_disabled.cf
@@ -1,0 +1,80 @@
+#####################################################################################
+# Copyright 2017 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name Service disabled at boot
+# @description Force a service not to be enabled at boot
+#
+# @parameter service_name Service name (as recognized by systemd, init.d, etc...)
+#
+# @class_prefix service_disabled
+# @class_parameter service_name
+# This bundle will define a class service_disabled_${canonified_service_name}_{kept,repaired,not_ok,ok,reached}
+
+bundle agent service_disabled(service_name)
+{
+  vars:
+
+    any::
+
+      "canonified_service_name" string => canonify("${service_name}");
+
+      "old_class_prefix"        string => "service_disabled_${canonified_service_name}";
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
+      "args"                     slist => { "${service_name}" };
+
+  methods:
+
+    !windows::
+      "disable_at_boot"
+        usebundle => service_check_disabled("${service_name}");
+
+      "undefine_at_boot"
+        usebundle => ncf_services("${service_name}", "disable"),
+        ifvarclass => "(!has_promiser_stack.service_check_disabled_${canonified_service_name}_not_ok)|(has_promiser_stack.${class_prefix}_check_disabled_not_ok)";
+
+      "already undefined"
+        usebundle  => _classes_success("${old_class_prefix}"),
+        ifvarclass => "service_check_disabled_${canonified_service_name}_ok";
+
+      "already undefined"
+        usebundle  => _classes_success("${class_prefix}"),
+        ifvarclass => "${class_prefix}_check_disabled_ok";
+
+      "copy classes"
+        usebundle  => _classes_copy("ncf_services_${canonified_service_name}_disable", "${old_class_prefix}"),
+        ifvarclass => "service_check_disabled_${canonified_service_name}_not_ok";
+
+      "copy classes"
+        usebundle  => _classes_copy("${class_prefix}_disable", "${class_prefix}"),
+        ifvarclass => "${class_prefix}_check_disabled_not_ok";
+
+    windows::
+      "action"             usebundle => service_stop("${service_name}");
+
+      "class copy"         usebundle => _classes_copy("service_stop_${canonified_service_name}", "${old_class_prefix}"),
+                          ifvarclass => "service_stop_${canonified_service_name}_reached";
+      "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                          ifvarclass => "${class_prefix}_action_reached";
+
+   any::
+      "report"
+        usebundle => _log("Ensure service ${service_name} is disabled at boot", "${old_class_prefix}", "${class_prefix}", @{args}),
+        ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
+
+}

--- a/tree/30_generic_methods/service_enabled.cf
+++ b/tree/30_generic_methods/service_enabled.cf
@@ -1,0 +1,79 @@
+#####################################################################################
+# Copyright 2014 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name Service enabled at boot
+# @description Force a service to be started at boot
+#
+# @parameter service_name Service name (as recognized by systemd, init.d, Windows, SRC, SMF, etc...)
+#
+# @class_prefix service_enabled
+# @class_parameter service_name
+
+bundle agent service_enabled(service_name)
+{
+  vars:
+
+
+    any::
+
+      "canonified_service_name" string => canonify("${service_name}");
+
+      "old_class_prefix"        string => "service_enabled_${canonified_service_name}";
+      "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+      "class_prefix"      string => canonify(join("_", "promisers"));
+      "args"                     slist => { "${service_name}" };
+
+  methods:
+    !windows::
+      "check_at_boot"
+        usebundle => service_check_started_at_boot("${service_name}");
+
+      "define_at_boot"
+        usebundle => ncf_services("${service_name}", "enable"),
+        ifvarclass => "(!has_promiser_stack.service_check_started_at_boot_${canonified_service_name}_not_ok)|(has_promiser_stack.${class_prefix}_check_at_boot_not_ok)";
+
+      "already defined"
+        usebundle  => _classes_success("${old_class_prefix}"),
+        ifvarclass => "service_check_started_at_boot_${canonified_service_name}_ok";
+
+      "already defined"
+        usebundle  => _classes_success("${class_prefix}"),
+        ifvarclass => "${class_prefix}_check_at_boot_ok";
+
+      "copy classes"
+        usebundle  => _classes_copy("ncf_services_${canonified_service_name}_enable", "${old_class_prefix}"),
+        ifvarclass => "service_check_started_at_boot_${canonified_service_name}_not_ok";
+
+      "copy classes"
+        usebundle  => _classes_copy("${class_prefix}_define_at_boot", "${class_prefix}"),
+        ifvarclass => "${class_prefix}_check_at_boot_not_ok";
+
+    windows::
+      "action"             usebundle => service_start("${service_name}");
+
+      "class copy"         usebundle => _classes_copy("service_start_${canonified_service_name}", "${old_class_prefix}"),
+                          ifvarclass => "service_start_${canonified_service_name}_reached";
+      "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                          ifvarclass => "${class_prefix}_action_reached";
+
+   any::
+      "report"
+        usebundle => _log("Ensure service ${service_name} is started at boot", "${old_class_prefix}", "${class_prefix}", @{args}),
+        ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
+
+}

--- a/tree/30_generic_methods/service_ensure_disabled_at_boot.cf
+++ b/tree/30_generic_methods/service_ensure_disabled_at_boot.cf
@@ -17,6 +17,8 @@
 #####################################################################################
 
 # @name Service ensure disabled at boot
+# @rename service_disabled_at_boot
+# @deprecated Use [service_disabled_at_boot](#service_disabled_at_boot) instead.
 # @description Force a service not to be enabled at boot
 #
 # @parameter service_name Service name (as recognized by systemd, init.d, etc...)
@@ -39,42 +41,12 @@ bundle agent service_ensure_disabled_at_boot(service_name)
       "args"                     slist => { "${service_name}" };
 
   methods:
-
-    !windows::
-      "disable_at_boot"
-        usebundle => service_check_disabled_at_boot("${service_name}");
-
-      "undefine_at_boot"
-        usebundle => ncf_services("${service_name}", "disable"),
-        ifvarclass => "(!has_promiser_stack.service_check_disabled_at_boot_${canonified_service_name}_not_ok)|(has_promiser_stack.${class_prefix}_check_disabled_at_boot_not_ok)";
-
-      "already undefined"
-        usebundle  => _classes_success("${old_class_prefix}"),
-        ifvarclass => "service_check_disabled_at_boot_${canonified_service_name}_ok";
-
-      "already undefined"
-        usebundle  => _classes_success("${class_prefix}"),
-        ifvarclass => "${class_prefix}_check_disabled_at_boot_ok";
-
-      "copy classes"
-        usebundle  => _classes_copy("ncf_services_${canonified_service_name}_disable", "${old_class_prefix}"),
-        ifvarclass => "service_check_disabled_at_boot_${canonified_service_name}_not_ok";
-
-      "copy classes"
-        usebundle  => _classes_copy("${class_prefix}_disable_at_boot", "${class_prefix}"),
-        ifvarclass => "${class_prefix}_check_disabled_at_boot_not_ok";
-
-    windows::
-      "action"             usebundle => service_stop("${service_name}");
-
-      "class copy"         usebundle => _classes_copy("service_stop_${canonified_service_name}", "${old_class_prefix}"),
-                          ifvarclass => "service_stop_${canonified_service_name}_reached";
-      "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
-                          ifvarclass => "${class_prefix}_action_reached";
-
-   any::
-      "report"
-        usebundle => _log("Ensure service ${service_name} is disabled at boot", "${old_class_prefix}", "${class_prefix}", @{args}),
-        ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
+    "action"             usebundle => service_disabled("${service_name}");
+    "class copy"         usebundle => _classes_copy("service_disabled_${canonified_service_name}", "${old_class_prefix}"),
+                         ifvarclass => "service_disabled_${canonified_service_name}_reached";
+    "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                         ifvarclass => "${class_prefix}_action_reached";
+    "report"
+        usebundle => _log("Ensure service ${service_name} is disabled at boot", "${old_class_prefix}", "${class_prefix}", @{args});:q
 
 }

--- a/tree/30_generic_methods/service_ensure_running.cf
+++ b/tree/30_generic_methods/service_ensure_running.cf
@@ -18,6 +18,8 @@
 
 # @name Service ensure running
 # @description Ensure that a service is running using the appropriate method
+# @rename service_started
+# @deprecated Use [service_started](#service_started) instead.
 #
 # @parameter service_name Service name (as recognized by systemd, init.d, etc...)
 # 
@@ -35,47 +37,12 @@ bundle agent service_ensure_running(service_name)
     "args"                          slist => { "${service_name}" };
 
   methods:
-    
-    !windows::
-      "check_running" usebundle  => service_check_running("${service_name}");
-
-    !windows.has_promiser_stack::
-      "start if not running"
-        usebundle  => service_start("${service_name}"),
-        ifvarclass => "!${class_prefix}_check_running_kept";
-
-      "class copy if not running"
-        usebundle  => _classes_copy("${class_prefix}_start_if_not_running", "${class_prefix}"),
-        ifvarclass => "!${class_prefix}_check_running_kept";
-
-      "class if running"
-        usebundle  => _classes_success("${class_prefix}"),
-        ifvarclass => "${class_prefix}_check_running_kept";
- 
-    !windows.!has_promiser_stack::
-      "start if not running"
-        usebundle  => service_start("${service_name}"),
-        ifvarclass => "!service_check_running_${canonified_service_name}_kept";
-
-      "class copy if not running"
-        usebundle  => _classes_copy("service_start_${canonified_service_name}", "${old_class_prefix}"),
-        ifvarclass => "!service_check_running_${canonified_service_name}_kept";
-
-      "class if running"
-        usebundle  => _classes_success("${old_class_prefix}"),
-        ifvarclass => "service_check_running_${canonified_service_name}_kept";
- 
-    windows::
-      "action"             usebundle => service_start("${service_name}");
-
-      "class copy"         usebundle => _classes_copy("service_start_${canonified_service_name}", "${old_class_prefix}"),
-                          ifvarclass => "service_start_${canonified_service_name}_reached";
-      "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
-                          ifvarclass => "${class_prefix}_action_reached";
-
-    any::
-      "report"
-        usebundle  => _log("Ensure that service ${service_name} is running", "${old_class_prefix}", "${class_prefix}", @{args}),
-        ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
+    "action"             usebundle => service_started("${service_name}");
+    "class copy"         usebundle => _classes_copy("service_started_${canonified_service_name}", "${old_class_prefix}"),
+                         ifvarclass => "service_started_${canonified_service_name}_reached";
+    "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                         ifvarclass => "${class_prefix}_action_reached";
+    "report"
+        usebundle  => _log("Ensure that service ${service_name} is running", "${old_class_prefix}", "${class_prefix}", @{args});
 
 }

--- a/tree/30_generic_methods/service_ensure_running_path.cf
+++ b/tree/30_generic_methods/service_ensure_running_path.cf
@@ -18,6 +18,9 @@
 
 # @name Service ensure running with service path
 # @description Ensure that a service is running using the appropriate method, specifying the path of the service in the ps output, or using Windows task manager
+# @rename service_started_path
+# @deprecated Use [service_started_path](#service_started_path) instead.
+
 # 
 # @parameter service_name Service name (as recognized by systemd, init.d, Windows, etc...)
 # @parameter service_path Service with its path, as in the output from 'ps'
@@ -38,46 +41,13 @@ bundle agent service_ensure_running_path(service_name, service_path)
     "args"                          slist => { "${service_name}", "${service_path}" };
 
   methods:
-    !windows::
-      "check running" usebundle  => service_check_running_ps("${service_path}");
+    "action"             usebundle => service_started_path("${service_name}", "${service_path}");
+    "class copy"         usebundle => _classes_copy("service_started_${canonified_service_name}", "${old_class_prefix}"),
+                         ifvarclass => "service_started_${canonified_service_name}_reached";
+    "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                         ifvarclass => "${class_prefix}_action_reached";
+    "report"
+        usebundle  => _log("Ensure that service ${service_name} is running", "${old_class_prefix}", "${class_prefix}", @{args});
 
-    !windows.has_promiser_stack::
-      "start if not running"
-        usebundle  => service_start("${service_name}"),
-        ifvarclass => "!${class_prefix}_check_running_kept";
-
-      "class copy if not running"
-        usebundle  => _classes_copy("${class_prefix}_start_if_not_running", "${class_prefix}"),
-        ifvarclass => "!${class_prefix}_check_running_kept";
-
-      "class if running"
-        usebundle  => _classes_success("${class_prefix}"),
-        ifvarclass => "${class_prefix}_check_running_kept";
- 
-    !windows.!has_promiser_stack::
-      "start if not running"
-        usebundle  => service_start("${service_name}"),
-        ifvarclass => "!service_check_running_${canonified_service_path}_kept";
-
-      "class copy if not running"
-        usebundle  => _classes_copy("service_start_${canonified_service_name}", "${old_class_prefix}"),
-        ifvarclass => "!service_check_running_${canonified_service_path}_kept";
-
-      "class if running"
-        usebundle  => _classes_success("${old_class_prefix}"),
-        ifvarclass => "service_check_running_${canonified_service_path}_kept";
- 
-    windows::
-      "action"             usebundle => service_start("${service_name}");
-
-      "class copy"         usebundle => _classes_copy("service_start_${canonified_service_name}", "${old_class_prefix}"),
-                          ifvarclass => "service_start_${canonified_service_name}_reached";
-      "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
-                          ifvarclass => "${class_prefix}_action_reached";
-
-    any::
-      "report"
-        usebundle  => _log("Ensure that service ${service_name} is running", "${old_class_prefix}", "${class_prefix}", @{args}),
-        ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
 
 }

--- a/tree/30_generic_methods/service_ensure_started_at_boot.cf
+++ b/tree/30_generic_methods/service_ensure_started_at_boot.cf
@@ -18,6 +18,8 @@
 
 # @name Service ensure started at boot
 # @description Force a service to be started at boot
+# @rename service_enabled
+# @deprecated Use [service_enabled](#service_enabled) instead.
 #
 # @parameter service_name Service name (as recognized by systemd, init.d, Windows, SRC, SMF, etc...)
 #
@@ -32,7 +34,6 @@ bundle agent service_ensure_started_at_boot(service_name)
     any::
 
       "canonified_service_name" string => canonify("${service_name}");
-      "canonified_command_name" string => canonify("${command_to_register}");
 
       "old_class_prefix"        string => "service_ensure_started_at_boot_${canonified_service_name}";
       "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
@@ -40,41 +41,12 @@ bundle agent service_ensure_started_at_boot(service_name)
       "args"                     slist => { "${service_name}" };
 
   methods:
-    !windows::
-      "check_at_boot"
-        usebundle => service_check_started_at_boot("${service_name}");
-
-      "define_at_boot"
-        usebundle => ncf_services("${service_name}", "enable"),
-        ifvarclass => "(!has_promiser_stack.service_check_started_at_boot_${canonified_service_name}_not_ok)|(has_promiser_stack.${class_prefix}_check_at_boot_not_ok)";
-
-      "already defined"
-        usebundle  => _classes_success("${old_class_prefix}"),
-        ifvarclass => "service_check_started_at_boot_${canonified_service_name}_ok";
-
-      "already defined"
-        usebundle  => _classes_success("${class_prefix}"),
-        ifvarclass => "${class_prefix}_check_at_boot_ok";
-
-      "copy classes"
-        usebundle  => _classes_copy("ncf_services_${canonified_service_name}_enable", "${old_class_prefix}"),
-        ifvarclass => "service_check_started_at_boot_${canonified_service_name}_not_ok";
-
-      "copy classes"
-        usebundle  => _classes_copy("${class_prefix}_define_at_boot", "${class_prefix}"),
-        ifvarclass => "${class_prefix}_check_at_boot_not_ok";
-
-    windows::
-      "action"             usebundle => service_start("${service_name}");
-
-      "class copy"         usebundle => _classes_copy("service_start_${canonified_service_name}", "${old_class_prefix}"),
-                          ifvarclass => "service_start_${canonified_service_name}_reached";
-      "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
-                          ifvarclass => "${class_prefix}_action_reached";
-
-   any::
-      "report"
-        usebundle => _log("Ensure service ${service_name} is started at boot", "${old_class_prefix}", "${class_prefix}", @{args}),
-        ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
+    "action"             usebundle => service_stopped("${service_name}");
+    "class copy"         usebundle => _classes_copy("service_enabled_${canonified_service_name}", "${old_class_prefix}"),
+                         ifvarclass => "service_enabled_${canonified_service_name}_reached";
+    "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                         ifvarclass => "${class_prefix}_action_reached";
+    "report"
+        usebundle => _log("Ensure service ${service_name} is started at boot", "${old_class_prefix}", "${class_prefix}", @{args});
 
 }

--- a/tree/30_generic_methods/service_ensure_stopped.cf
+++ b/tree/30_generic_methods/service_ensure_stopped.cf
@@ -18,6 +18,8 @@
 
 # @name Service ensure stopped
 # @description Ensure that a service is stopped using the appropriate method
+# @rename service_stopped
+# @deprecated Use [service_stopped](#service_stopped) instead.
 #
 # @parameter service_name Service
 # 
@@ -37,43 +39,12 @@ bundle agent service_ensure_stopped(service_name)
 
   methods:
 
-    !windows::
-      "check running"
-        usebundle  => service_check_running("${service_name}");
-
-      # If service_check_running has detected a process, it will result in
-      # a success, so we have to stop the process
-      "stop if running"
-        usebundle  => service_stop("${service_name}"),
-        ifvarclass => "(!has_promiser_stack.service_check_running_${canonified_service_name}_kept)|(has_promiser_stack.${class_prefix}_check_running_kept)";
-
-      # If service_check_running has no detected any process, it will not result
-      # in a success so the result class of this promise should be the a success.
-      "create success class"
-        usebundle  => _classes_success("${old_class_prefix}"),
-        ifvarclass => "(!has_promiser_stack.!service_check_running_${canonified_service_name}_kept)|(has_promiser_stack.!${class_prefix}_check_running_kept)";
- 
-     # If service_check_running has detected a process, the process will be
-     # stopped and the result class should be the same as this promise.
-      "class copy if running"
-        usebundle  => _classes_copy("service_stop_${canonified_service_name}", "${old_class_prefix}"),
-        ifvarclass => "service_check_running_${canonified_service_name}_kept";
-
-      "class copy if running"
-        usebundle  => _classes_copy("${class_prefix}_stop_if_running", "${class_prefix}"),
-        ifvarclass => "has_promiser_stack.${class_prefix}_check_running_kept";
-
-    windows::
-      "action"             usebundle => service_stop("${service_name}");
-
-      "class copy"         usebundle => _classes_copy("service_stop_${canonified_service_name}", "${old_class_prefix}"),
-                          ifvarclass => "service_stop_${canonified_service_name}_reached";
-      "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
-                          ifvarclass => "${class_prefix}_action_reached";
-
-    any::
-      "report"
-        usebundle  => _log("Ensure that service ${service_name} is stopped", "${old_class_prefix}", "${class_prefix}", @{args}),
-        ifvarclass =>"(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.!${class_prefix}_reached)";
+    "action"             usebundle => service_stopped("${service_name}");
+    "class copy"         usebundle => _classes_copy("service_stopped_${canonified_service_name}", "${old_class_prefix}"),
+                         ifvarclass => "service_stopped_${canonified_service_name}_reached";
+    "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                         ifvarclass => "${class_prefix}_action_reached";
+    "report"
+        usebundle  => _log("Ensure that service ${service_name} is stopped", "${old_class_prefix}", "${class_prefix}", @{args});
 
 }

--- a/tree/30_generic_methods/service_started.cf
+++ b/tree/30_generic_methods/service_started.cf
@@ -1,0 +1,81 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name Service started
+# @description Ensure that a service is running using the appropriate method
+#
+# @parameter service_name Service name (as recognized by systemd, init.d, etc...)
+# 
+# @class_prefix service_started
+# @class_parameter service_name
+
+bundle agent service_started(service_name)
+{
+  vars:
+    "canonified_service_name"      string => canonify("${service_name}");
+
+    "old_class_prefix"             string => "service_started_${canonified_service_name}";
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
+    "args"                          slist => { "${service_name}" };
+
+  methods:
+    
+    !windows::
+      "check_running" usebundle  => service_check_running("${service_name}");
+
+    !windows.has_promiser_stack::
+      "start if not running"
+        usebundle  => service_start("${service_name}"),
+        ifvarclass => "!${class_prefix}_check_running_kept";
+
+      "class copy if not running"
+        usebundle  => _classes_copy("${class_prefix}_start_if_not_running", "${class_prefix}"),
+        ifvarclass => "!${class_prefix}_check_running_kept";
+
+      "class if running"
+        usebundle  => _classes_success("${class_prefix}"),
+        ifvarclass => "${class_prefix}_check_running_kept";
+ 
+    !windows.!has_promiser_stack::
+      "start if not running"
+        usebundle  => service_start("${service_name}"),
+        ifvarclass => "!service_check_running_${canonified_service_name}_kept";
+
+      "class copy if not running"
+        usebundle  => _classes_copy("service_start_${canonified_service_name}", "${old_class_prefix}"),
+        ifvarclass => "!service_check_running_${canonified_service_name}_kept";
+
+      "class if running"
+        usebundle  => _classes_success("${old_class_prefix}"),
+        ifvarclass => "service_check_running_${canonified_service_name}_kept";
+ 
+    windows::
+      "action"             usebundle => service_start("${service_name}");
+
+      "class copy"         usebundle => _classes_copy("service_start_${canonified_service_name}", "${old_class_prefix}"),
+                          ifvarclass => "service_start_${canonified_service_name}_reached";
+      "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                          ifvarclass => "${class_prefix}_action_reached";
+
+    any::
+      "report"
+        usebundle  => _log("Ensure that service ${service_name} is running", "${old_class_prefix}", "${class_prefix}", @{args}),
+        ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
+
+}

--- a/tree/30_generic_methods/service_started_path.cf
+++ b/tree/30_generic_methods/service_started_path.cf
@@ -1,0 +1,83 @@
+#####################################################################################
+# Copyright 2014 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name Service started with service path
+# @description Ensure that a service is running using the appropriate method, specifying the path of the service in the ps output, or using Windows task manager
+# 
+# @parameter service_name Service name (as recognized by systemd, init.d, Windows, etc...)
+# @parameter service_path Service with its path, as in the output from 'ps'
+
+# @class_prefix service_started
+# @class_parameter service_name
+
+bundle agent service_started_path(service_name, service_path)
+{
+  vars:
+
+    "canonified_service_name"      string => canonify("${service_name}");
+    "canonified_service_path"      string => canonify("${service_path}");
+
+    "old_class_prefix"             string => "service_started_${canonified_service_name}";
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
+    "args"                          slist => { "${service_name}", "${service_path}" };
+
+  methods:
+    !windows::
+      "check running" usebundle  => service_check_running_ps("${service_path}");
+
+    !windows.has_promiser_stack::
+      "start if not running"
+        usebundle  => service_start("${service_name}"),
+        ifvarclass => "!${class_prefix}_check_running_kept";
+
+      "class copy if not running"
+        usebundle  => _classes_copy("${class_prefix}_start_if_not_running", "${class_prefix}"),
+        ifvarclass => "!${class_prefix}_check_running_kept";
+
+      "class if running"
+        usebundle  => _classes_success("${class_prefix}"),
+        ifvarclass => "${class_prefix}_check_running_kept";
+ 
+    !windows.!has_promiser_stack::
+      "start if not running"
+        usebundle  => service_start("${service_name}"),
+        ifvarclass => "!service_check_running_${canonified_service_path}_kept";
+
+      "class copy if not running"
+        usebundle  => _classes_copy("service_start_${canonified_service_name}", "${old_class_prefix}"),
+        ifvarclass => "!service_check_running_${canonified_service_path}_kept";
+
+      "class if running"
+        usebundle  => _classes_success("${old_class_prefix}"),
+        ifvarclass => "service_check_running_${canonified_service_path}_kept";
+ 
+    windows::
+      "action"             usebundle => service_start("${service_name}");
+
+      "class copy"         usebundle => _classes_copy("service_start_${canonified_service_name}", "${old_class_prefix}"),
+                          ifvarclass => "service_start_${canonified_service_name}_reached";
+      "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                          ifvarclass => "${class_prefix}_action_reached";
+
+    any::
+      "report"
+        usebundle  => _log("Ensure that service ${service_name} is running", "${old_class_prefix}", "${class_prefix}", @{args}),
+        ifvarclass => "(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.${class_prefix}_reached)";
+
+}

--- a/tree/30_generic_methods/service_stopped.cf
+++ b/tree/30_generic_methods/service_stopped.cf
@@ -1,0 +1,79 @@
+#####################################################################################
+# Copyright 2013 Normation SAS
+#####################################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, Version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################################
+
+# @name Service stopped
+# @description Ensure that a service is stopped using the appropriate method
+#
+# @parameter service_name Service
+# 
+# @class_prefix service_stopped
+# @class_parameter service_name
+
+bundle agent service_stopped(service_name)
+{
+  vars:
+
+    "canonified_service_name"      string => canonify("${service_name}");
+
+    "old_class_prefix"             string => "service_stopped_${canonified_service_name}";
+    "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
+    "class_prefix"      string => canonify(join("_", "promisers"));
+    "args"                          slist => { "${service_name}" };
+
+  methods:
+
+    !windows::
+      "check running"
+        usebundle  => service_check_running("${service_name}");
+
+      # If service_check_running has detected a process, it will result in
+      # a success, so we have to stop the process
+      "stop if running"
+        usebundle  => service_stop("${service_name}"),
+        ifvarclass => "(!has_promiser_stack.service_check_running_${canonified_service_name}_kept)|(has_promiser_stack.${class_prefix}_check_running_kept)";
+
+      # If service_check_running has no detected any process, it will not result
+      # in a success so the result class of this promise should be the a success.
+      "create success class"
+        usebundle  => _classes_success("${old_class_prefix}"),
+        ifvarclass => "(!has_promiser_stack.!service_check_running_${canonified_service_name}_kept)|(has_promiser_stack.!${class_prefix}_check_running_kept)";
+ 
+     # If service_check_running has detected a process, the process will be
+     # stopped and the result class should be the same as this promise.
+      "class copy if running"
+        usebundle  => _classes_copy("service_stop_${canonified_service_name}", "${old_class_prefix}"),
+        ifvarclass => "service_check_running_${canonified_service_name}_kept";
+
+      "class copy if running"
+        usebundle  => _classes_copy("${class_prefix}_stop_if_running", "${class_prefix}"),
+        ifvarclass => "has_promiser_stack.${class_prefix}_check_running_kept";
+
+    windows::
+      "action"             usebundle => service_stop("${service_name}");
+
+      "class copy"         usebundle => _classes_copy("service_stop_${canonified_service_name}", "${old_class_prefix}"),
+                          ifvarclass => "service_stop_${canonified_service_name}_reached";
+      "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                          ifvarclass => "${class_prefix}_action_reached";
+
+    any::
+      "report"
+        usebundle  => _log("Ensure that service ${service_name} is stopped", "${old_class_prefix}", "${class_prefix}", @{args}),
+        ifvarclass =>"(!has_promiser_stack.${old_class_prefix}_reached)|(has_promiser_stack.!${class_prefix}_reached)";
+
+}


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11879

Replacing previous PR: https://github.com/Normation/ncf/pull/667
