### PR TITLE
Fixes #12161: ncf 4.3 now requires CFEngine >= 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Each level uses items from lower levels (lower numbers) or, in some cases, from 
 
 ## Requirements
 
-There are none, other than CFEngine itself. ncf currently supports CFEngine 3.7 and higher.
+There are none, other than CFEngine itself. ncf currently supports CFEngine 3.10 and higher.
 
 ncf is a pure-CFEngine framework, so you can just add it in your CFEngine policy files. Nothing else is needed.
 

--- a/tree/30_generic_methods/file_from_template_mustache.cf
+++ b/tree/30_generic_methods/file_from_template_mustache.cf
@@ -158,7 +158,7 @@
 # prop2 -> value2
 # ```
 #
-# Note: Starting from CFEngine 3.7, you can use `{{#-top-}} ... {{/-top-}}`
+# Note: You can use `{{#-top-}} ... {{/-top-}}`
 # to iterate over the top level container.
 #
 # @agent_version >=3.6


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12161