### PR TITLE
Fixes #12226: Broken file_enforce_content  generic method in 4.3 due to upmerge

### DIFF
--- a/tree/30_generic_methods/file_enforce_content.cf
+++ b/tree/30_generic_methods/file_enforce_content.cf
@@ -50,6 +50,13 @@ bundle agent file_enforce_content(file, lines, enforce)
     islist::
       "report_string" string => join(", ", "lines");
 
+  classes:
+    !pass2::
+      "islist" expression => isgreaterthan("$(length_list)", "1");
+
+      "pass2" expression => "pass1";
+      "pass1" expression => "any";
+
   methods:
     !islist.pass2::
       "action"              usebundle => file_content("${file}", "${lines}", "${enforce}");

--- a/tree/30_generic_methods/file_ensure_lines_present.cf
+++ b/tree/30_generic_methods/file_ensure_lines_present.cf
@@ -30,12 +30,17 @@
 bundle agent file_ensure_lines_present(file, lines)
 {
   vars:
+      # old_class_prefix is not necessary, as file_enforce_content will report, with the same class prefix
       "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
       "class_prefix"      string => canonify(join("_", "promisers"));
-      "args"              slist => { "${file}", "${lines}" };
+      "args"               slist => { "${file}", "${lines}" };
+
 
   methods:
       "enforce lines content" usebundle => file_enforce_content("${file}", "${lines}", "false");
+      "new result classes"    usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                             ifvarclass => "${class_prefix}_action_reached";
+
       "new result classes"    usebundle => _classes_copy("${class_prefix}_enforce_lines_content", "${class_prefix}");
 
       "report"                usebundle => _log("Insert content ${lines} into ${file}", "", "${class_prefix}", @{args});


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12226