### PR TITLE
Fixes #12345: Missing report in Manage keys-values in file because of invalid conditions in ensure_key_value_option

### DIFF
--- a/tree/30_generic_methods/file_ensure_key_value_option.cf
+++ b/tree/30_generic_methods/file_ensure_key_value_option.cf
@@ -41,20 +41,20 @@ bundle agent file_ensure_key_value_option(file, key, value, separator, option)
       "promisers"          slist => { @{this.callers_promisers}, cf_null }, policy => "ifdefined";
       "class_prefix"      string => canonify(join("_", "promisers"));
       "args"              slist => { "${file}", "${key}", "${value}","${separator}", "${option}" };
-      "canonified_file"    string => canonify("${target}");
+      "canonified_file"    string => canonify("${file}");
 
 
   classes:
       "should_report"    expression => "${report_data.should_report}";
 
   methods:
-      "disable_reporting"     usebundle => disable_reporting;
-    "action"             usebundle => file_key_value_present_option("${file}", "${key}", "${value}","${separator}", "${option}");
-      "reenable_reporting"    usebundle => enable_reporting,
-                             ifvarclass => "should_report";
-    "class copy"         usebundle => _classes_copy("file_key_value_present_${canonified_file}", "${old_class_prefix}"),
-                         ifvarclass => "file_present_${canonified_file}_reached";
-    "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
-                         ifvarclass => "${class_prefix}_action_reached";
-    "report"   usebundle => _log("Ensure line in format key${separator}value in ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "disable_reporting"  usebundle => disable_reporting;
+      "action"             usebundle => file_key_value_present_option("${file}", "${key}", "${value}","${separator}", "${option}");
+      "reenable_reporting" usebundle => enable_reporting,
+                          ifvarclass => "should_report";
+      "class copy"         usebundle => _classes_copy("file_key_value_present_${canonified_file}", "${old_class_prefix}"),
+                          ifvarclass => "file_key_value_present_${canonified_file}_reached";
+      "new result classes" usebundle => _classes_copy("${class_prefix}_action", "${class_prefix}"),
+                          ifvarclass => "${class_prefix}_action_reached";
+      "report"             usebundle => _log("Ensure line in format key${separator}value in ${file}", "${old_class_prefix}", "${class_prefix}", @{args});
 }


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12345