### PR TITLE
Fixes #12442: Broken reporting for generic method file_ensure_key_value_option

### DIFF
--- a/tree/30_generic_methods/file_ensure_key_value_option.cf
+++ b/tree/30_generic_methods/file_ensure_key_value_option.cf
@@ -41,7 +41,7 @@ bundle agent file_ensure_key_value_option(file, key, value, separator, option)
       "args"                slist => { "${file}", "${key}", "${value}","${separator}", "${option}" };
 
       "report_param"       string => join("_", args);
-      "inner_class_prefix" string => canonify("file_key_value_present_${file}_${report_param}");
+      "inner_class_prefix" string => canonify("file_key_value_present_${report_param}");
       "class_prefix"       string => canonify("file_ensure_key_value_${report_param}");
 
   classes:


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12442