### PR TITLE
Fixes #12266: In technique editor, mouse cursor on top of technique parameter "use with" should be a carret 

### DIFF
--- a/builder/css/custom.css
+++ b/builder/css/custom.css
@@ -408,6 +408,11 @@ ul[dnd-list] {
     position: absolute;
     right: 10px;
 }
+.editForm .form-control[readonly]{
+  cursor: text;
+  box-shadow: none !important;
+}
+
 input.form-control.ng-invalid.ng-dirty:focus{
     border-color: #b33630;
     outline: 0;

--- a/builder/index.html
+++ b/builder/index.html
@@ -242,7 +242,7 @@
                             <div class="form-group" show-errors>
                                 <label for="bundleName" class="col-sm-3 control-label">Bundle name:</label>
                                 <div class="col-sm-8">
-                                    <input disabled id="bundleName" bundlename name="bundle_name" class="form-control" ng-model="selectedTechnique.bundle_name" ng-maxlength="252" ng-pattern="/^[^_].*$/">
+                                    <input readonly id="bundleName" bundlename name="bundle_name" class="form-control" ng-model="selectedTechnique.bundle_name" ng-maxlength="252" ng-pattern="/^[^_].*$/">
                                 </div>
                                 <span class="text-danger col-sm-8 col-sm-offset-3" ng-show="editForm.bundle_name.$error.maxlength">
                                     Bundle names longer than 255 characters won't work on most filesystems.


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12266