### PR TITLE
Fixes #12639:  Use pylint to verify python code in ncf

### DIFF
--- a/qa-test
+++ b/qa-test
@@ -1,3 +1,6 @@
 #!/bin/bash
 
 make test-common
+
+find . -name '*.py' | xargs pylint -E --disable=C,R --persistent=n
+pylint -E --disable=C,R --persistent=n --init-hook="sys.path[0:0] = ['./tools']" ncf


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12639