### PR TITLE
Fixes #12887: fail to restart certain services on Ubuntu because of incomplete detection of systemd/upstart

### DIFF
--- a/tree/20_cfe_basics/ncf_lib.cf
+++ b/tree/20_cfe_basics/ncf_lib.cf
@@ -1218,7 +1218,7 @@ bundle agent ncf_services(service, action)
                               };
 
       # Due to lack of integration between upstart and init scripts, we have to make different cases.
-      "is_upstart_service"         not => returnszero("/sbin/initctl status ${service} 2>&1 | ${paths.path[grep]} 'Unknown job' > /dev/null", "useshell"),
+      "is_upstart_service"         not => returnszero("/sbin/initctl status ${service} 2>&1 | ${paths.path[grep]} -E 'Unknown job|Unable to connect to Upstart' > /dev/null", "useshell"),
                             ifvarclass => "ubuntu.initctl_utility_present";
 
       # Due to compatibility issues when mixing init.d/service and systemctl calls, we use the init script when present


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12887