### PR TITLE
Fixes #12953: In some cases, reporting context calls can be the same for different methods, and hence ignored

### DIFF
--- a/tools/ncf.py
+++ b/tools/ncf.py
@@ -552,6 +552,7 @@ def generate_technique_content(technique, methods):
   content.append('  methods:')
 
   # Handle method calls
+  report_unique_id = 0
   for method_call in technique["method_calls"]:
     method_name = method_call["method_name"]
     method_info = methods[method_name]
@@ -582,7 +583,8 @@ def generate_technique_content(technique, methods):
       promiser = "method_call"
 
     # Set bundle context, first escape paramters
-    content.append('    "'+promiser+'_context" usebundle => '+ generate_reporting_context(method_info, method_call) + ";")
+    content.append('    "'+promiser+'_context_' + str(report_unique_id) + '" usebundle => '+ generate_reporting_context(method_info, method_call) + ";")
+    report_unique_id += 1
 
     # Append method call
     content.append('    "'+promiser+'" usebundle => '+method_name+'('+arg_value+'),')

--- a/tools/ncf_rudder.py
+++ b/tools/ncf_rudder.py
@@ -198,6 +198,8 @@ def generate_rudder_reporting(technique):
   content.append('')
   content.append('  methods:')
 
+  report_unique_id = 0
+
   for method_call in technique["method_calls"]:
 
     method_name = method_call['method_name']
@@ -208,7 +210,8 @@ def generate_rudder_reporting(technique):
     key_value = ncf.get_key_value(method_call, generic_method)
 
     class_prefix = ncf.get_class_prefix(key_value, generic_method)
-    method_reporting = '"dummy_report" usebundle => ' + ncf.generate_reporting_context(generic_method, method_call) 
+    method_reporting = '"dummy_report_' + str(report_unique_id) + '" usebundle => ' + ncf.generate_reporting_context(generic_method, method_call) 
+    report_unique_id += 1
     class_parameter  = ncf.generate_reporting_class_parameter(generic_method, method_call)
 
     if not "cfengine-community" in generic_method["agent_support"]:


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12953