### PR TITLE
Fixes #13523: variable_string and variable_string_default GM are failing in rudder 5.0

### DIFF
--- a/tests/acceptance/30_generic_methods/variable_string.cf
+++ b/tests/acceptance/30_generic_methods/variable_string.cf
@@ -23,7 +23,7 @@ bundle agent init
 {
   vars:
     "var" string => "var2";
-    "prefix" string => "test";
+    "prefix" string => "prefix1";
 }
 
 #######################################################
@@ -32,7 +32,7 @@ bundle agent test
 {
   methods:
     "ph1" usebundle => variable_string("${init.prefix}", "var1", "${init.var}");
-    "ph2" usebundle => variable_string("test", "var2", "value");
+    "ph2" usebundle => variable_string("prefix1", "var2", "value");
 }
 
 #######################################################
@@ -43,9 +43,9 @@ bundle agent check
     
     "ok_1" expression => "variable_string_var1_kept.!variable_string_var1_repaired.!variable_string_var1_error";
     "ok_2" expression => "variable_string_var2_kept.!variable_string_var2_repaired.!variable_string_var2_error";
-    "ok_var1" expression => strcmp("${test.var1}", "${init.var}");
+    "ok_var1" expression => strcmp("${prefix1.var1}", "${init.var}");
     "ok_var1_bis" expression => strcmp("${${init.prefix}.var1}", "${init.var}");
-    "ok_var2"  expression => strcmp("${test.var2}", "value");
+    "ok_var2"  expression => strcmp("${prefix1.var2}", "value");
     "ok_var2_bis"  expression => strcmp("${${init.prefix}.${${init.prefix}.var1}}", "value");
 
     "ok"  expression => "ok_1.ok_2.ok_var1.ok_var1_bis.ok_var2.ok_var2_bis";

--- a/tests/acceptance/30_generic_methods/variable_string_default.cf
+++ b/tests/acceptance/30_generic_methods/variable_string_default.cf
@@ -23,7 +23,7 @@ bundle agent init
 {
   vars:
     "var" string => "var2";
-    "prefix" string => "test";
+    "prefix" string => "prefix1";
 }
 
 #######################################################
@@ -32,8 +32,8 @@ bundle agent test
 {
   methods:
     "ph1" usebundle => variable_string_default("${init.prefix}", "var1", "init.var", "default1");
-    "ph2" usebundle => variable_string_default("test", "var2", "init.var", "default2");
-    "ph3" usebundle => variable_string_default("test", "var3", "init.undef", "default3");
+    "ph2" usebundle => variable_string_default("prefix1", "var2", "init.var", "default2");
+    "ph3" usebundle => variable_string_default("prefix1", "var3", "init.undef", "default3");
 }
 
 #######################################################
@@ -45,11 +45,11 @@ bundle agent check
     "ok_1" expression => "variable_string_default_var1_kept.!variable_string_default_var1_repaired.!variable_string_default_var1_error";
     "ok_2" expression => "variable_string_default_var2_kept.!variable_string_default_var2_repaired.!variable_string_default_var2_error";
     "ok_3" expression => "variable_string_default_var3_kept.!variable_string_default_var3_repaired.!variable_string_default_var3_error";
-    "ok_var1" expression => strcmp("${test.var1}", "${init.var}");
+    "ok_var1" expression => strcmp("${prefix1.var1}", "${init.var}");
     "ok_var1_bis" expression => strcmp("${${init.prefix}.var1}", "${init.var}");
-    "ok_var2"  expression => strcmp("${test.var2}", "${init.var}");
+    "ok_var2"  expression => strcmp("${prefix1.var2}", "${init.var}");
     "ok_var2_bis"  expression => strcmp("${${init.prefix}.${${init.prefix}.var2}}", "${init.var}");
-    "ok_var3" expression => strcmp("${test.var3}", "default3");
+    "ok_var3" expression => strcmp("${prefix1.var3}", "default3");
 
     "ok"  expression => "ok_1.ok_2.ok_var1.ok_var1_bis.ok_var2.ok_var2_bis.ok_3.ok_var3";
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13523

Replacing previous PR: https://github.com/Normation/ncf/pull/826
