### PR TITLE
Fixes #13703: Missing report when using the package_state GM with default arg for the "state" parameter

### DIFF
--- a/tree/30_generic_methods/package_state.cf
+++ b/tree/30_generic_methods/package_state.cf
@@ -131,13 +131,12 @@
 bundle agent package_state(name, version, architecture, provider, state)
 {
   vars:
+    pass1::
       "canonified_name"           string => canonify("${name}");
       "canonified_state"          string => canonify("${state}");
 
       "old_class_prefix"          string => "package_state_${canonified_name}";
 
-    # don't rewrite the class prefix based on defaults
-    !pass1::
       "args"                      slist  => { "${name}", "${version}", "${architecture}", "${provider}", "${state}" };
       "report_param"              string => join("_", args);
       "full_class_prefix"         string => canonify("package_state_${report_param}");
@@ -153,9 +152,11 @@ bundle agent package_state(name, version, architecture, provider, state)
   classes:
       "should_report"         expression => "${report_data.should_report}";
 
+      "pass2" expression => "pass1";
       "pass1" expression => "any";
 
   methods:
+    pass2::
       "disable_reporting_${class_prefix}"
                                usebundle => disable_reporting;
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13703