### PR TITLE
Fixes #13722: style test nbsp_is_not_allowed.sh always fails, missing 4.1 version of 13637

### DIFF
--- a/tests/style/tests/nbsp_is_not_allowed.sh
+++ b/tests/style/tests/nbsp_is_not_allowed.sh
@@ -5,7 +5,7 @@ set -e
 # NBSP breaks scripts and cfengine code, they should never appear
 
 # Build fine arguments
-FIND_ARGS="-type f -not -wholename */.git/* -not -wholename */api/flask/* -not -name *.png -not -name *.eot -not -name *.ttf -not -name *.woff -not -name *.otf -not -name *.js -not -name *.ico"
+FIND_ARGS="-type f -not -wholename */.git/* -not -wholename */api/flask/* -not -name *.png -not -name *.eot -not -name *.ttf -not -name *.woff -not -name *.otf -not -name *.js -not -name *.ico -not -name *.rpm"
 
 # Automatically exclude anything from the .gitignore file
 while read line


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13722