### PR TITLE
Fixes #13286: remove comment about classes_generic_two being deprecated

### DIFF
--- a/tree/20_cfe_basics/ncf_lib.cf
+++ b/tree/20_cfe_basics/ncf_lib.cf
@@ -874,8 +874,6 @@ body classes classes_generic_return_boolean_list_two(x, y, boolean_prefix, true_
                       "promise_kept_$(y)", "$(y)_kept", "$(y)_ok", "$(y)_not_repaired", "$(y)_reached", "${boolean_prefix}_true" };
 }
 
-# WARNING !!!
-# For new class prefix migration only, this will be removed when migration is over
 # Define x and y prefixed/suffixed with promise outcome
 body classes classes_generic_two(x,y)
 {


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13286