### PR TITLE
Fixes #13744: Time lib may not work when the first non-loopback interface has no ip adress

### DIFF
--- a/tree/20_cfe_basics/time_lib.cf
+++ b/tree/20_cfe_basics/time_lib.cf
@@ -67,7 +67,7 @@ bundle agent ncf_splay(test_splay)
       # maximum value of splay integer = 7 nibbles (2^28-1)
       "splay_max" string => "268435455";
       # pseudorandon deterministic hex number of 7 nibbles
-      "splay_hex" string => string_head(hash("${sys.host}${sys.ipv4}", "md5"), "7");
+      "splay_hex" string => string_head(hash("${sys.host}", "md5"), "7");
 
       # decimal version of the splay integer
     !windows::


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13744