### PR TITLE
Fixes #13931: Unparsable technique when Rudder server hostname is not in the /etc/hosts

### DIFF
--- a/tools/ncf.py
+++ b/tools/ncf.py
@@ -300,7 +300,6 @@ def parse_technique_methods(technique_file):
     raise NcfError("No such file: " + technique_file)
 
   env = os.environ.copy()
-  env['RES_OPTIONS'] = 'attempts:0'
   out = check_output(["cf-promises", "-pjson", "-f", technique_file], env=env)
   try:
     promises = json.loads(out)


### PR DESCRIPTION
https://issues.rudder.io/issues/13931