### PR TITLE
Fixes #13598: File copy from Rudder shared folder does not allow empty hash parameter

### DIFF
--- a/tree/30_generic_methods/file_from_shared_folder.cf
+++ b/tree/30_generic_methods/file_from_shared_folder.cf
@@ -21,8 +21,8 @@
 #
 # @parameter source      Source file (path, relative to /var/rudder/configuration-repository/shared-files)
 # @parameter destination Destination file (absolute path on the target node)
-# @parameter hash_type   Hash algorithm used to check if file is updated (md5, sha1, sha256). Only used on dsc agent, cfengine agent use it's own system for now. 
-# @parameter_constraint hash_type  "select" : [ "md5", "sha1", "sha256" ]
+# @parameter hash_type   Hash algorithm used to check if file is updated (md5, sha1, sha256). Only used on Windows, ignored on Unix.
+# @parameter_constraint hash_type "select" : [ "md5", "sha1", "sha256" ]
 # 
 # @class_prefix file_from_shared_folder
 # @class_parameter destination
@@ -41,8 +41,6 @@ bundle agent file_from_shared_folder(source, destination, hash_type)
 
       "full_inner_class_prefix" string => canonify("file_from_remote_source_${report_param}_inf");
       "inner_class_prefix"      string => string_head("${full_inner_class_prefix}", "1000");
-
-
 
   classes:
       "should_report"    expression => "${report_data.should_report}";


### PR DESCRIPTION
https://issues.rudder.io/issues/13598