### PR TITLE
Fixes #14911: in 5.1 the bundle ncf_configuration_basedir does not exists anymore 

### DIFF
--- a/tests/acceptance/default_ncf.cf.sub
+++ b/tests/acceptance/default_ncf.cf.sub
@@ -1,3 +1,8 @@
+# Needed to have a path reference for the tests execution
+bundle common ncf_configuration {
+  vars:
+      "ncf_configuration_basedir" string => dirname("${this.promise_filename}");
+}
 # Create the list of all the base file to load to test
 # It requires the NCF_TREE environment variable to be defined
 bundle common ncf_inputs


### PR DESCRIPTION
https://issues.rudder.io/issues/14911