### PR TITLE
Fixes #15280: Class_prefix and old_class_prefix tests need python3 which is not available on old OS

### DIFF
--- a/tests/unit/testall
+++ b/tests/unit/testall
@@ -24,4 +24,6 @@ NCF_TREE=`cd "${OUR_DIR}" && pwd`/../../tree
 export PYTHONPATH=${NCF_TREE}/../tools/:$PYTHONPATH
 python test_ncf.py
 python test_ncf_rudder.py
-python3 test_class_prefix.py
+if command -v python3 > /dev/null; then
+  python3 test_class_prefix.py
+fi


### PR DESCRIPTION
https://issues.rudder.io/issues/15280