### PR TITLE
Fixes #15771: ncf test for service_check_running_ps fails on centos6

### DIFF
--- a/tests/acceptance/30_generic_methods/service_check_running_ps.cf
+++ b/tests/acceptance/30_generic_methods/service_check_running_ps.cf
@@ -22,10 +22,12 @@ body common control
 bundle agent init
 {
   vars:
-    !ubuntu::
+    !ubuntu.!redhat::
       "service_regex_1"            string => "/usr/sbin/cron";
     ubuntu::
       "service_regex_1"            string => "cron";
+    redhat::
+      "service_regex_1"            string => "crond";
     any::
       "service_regex_2"            string => "thisisadummyservice";
       "canonified_service_regex_1" string => canonify("${service_regex_1}");


### PR DESCRIPTION
https://issues.rudder.io/issues/15771