### PR TITLE
Fixes #15780: user_primary_group tests method does not properly clean up all potentially created groups

### DIFF
--- a/tests/acceptance/30_generic_methods/unsafe/user_primary_group.cf
+++ b/tests/acceptance/30_generic_methods/unsafe/user_primary_group.cf
@@ -146,7 +146,8 @@ bundle agent check
 
   commands:
     pass2::
-      "${paths.userdel}  ${init.user[${init.indices}]}" handle => "h${init.indices}";
+      "${paths.userdel}  ${init.user[${init.indices}]}" handle => "deluser${init.indices}";
+      "${paths.groupdel} ${init.user[${init.indices}]}" handle => "delgroup${init.indices}";
       "${paths.groupdel} ${init.primary_group[1]}" handle => "del1";
       "${paths.groupdel} ${init.primary_group[2]}" handle => "del2";
 


### PR DESCRIPTION
https://issues.rudder.io/issues/15780