### PR TITLE
Fixes #14286: Using ${match.x} in generic method causes an error message in the agent output, and prevent multiple reporting based on this generic method

### DIFF
--- a/tree/30_generic_methods/file_replace_lines.cf
+++ b/tree/30_generic_methods/file_replace_lines.cf
@@ -47,13 +47,35 @@
 bundle agent file_replace_lines(file, line, replacement)
 {
   vars:
+    pass1::
       "old_class_prefix"  string => canonify("file_replace_lines_${file}");
+
+    # If replacement contains ${match.x}, it would not evaluate to anything outside of file promises, so we
+    # need to exclude it from class prefix
+    pass1.replacement_non_eval::
+      "args"               slist => { "${file}", "${line}" };
+
+    pass1.!replacement_non_eval::
       "args"               slist => { "${file}", "${line}", "${replacement}" };
+
+    pass1::
       "report_param"      string => join("_", args);
       "full_class_prefix" string => canonify("file_replace_lines_${report_param}");
       "class_prefix"      string => string_head("${full_class_prefix}", "1000");
 
+  classes:
+      "replacement_defined"           not => strcmp("${replacement}", "");
+      "no_replacement_defined" expression => strcmp("${replacement}", "");
+
+      # if both classes are undefined then there is most likely a "match.x" in it, that is not evaluated
+      # by the agent (see https://issues.rudder.io/issues/15029 and https://issues.rudder.io/issues/14286
+      "replacement_non_eval"   expression => "!replacement_defined.!no_replacement_defined";
+
+      "pass2" expression => "pass1";
+      "pass1" expression => "any";
+
   files:
+    pass2::
       "${file}"
         create        => "false",
         edit_line     => regex_replace("${line}", "${replacement}"),
@@ -61,6 +83,7 @@ bundle agent file_replace_lines(file, line, replacement)
         classes       => classes_generic_two("${old_class_prefix}", "${class_prefix}");
 
   methods:
+    pass2::
       "sanitize" usebundle => _classes_sanitize("${class_prefix}");
       "sanitize" usebundle => _classes_sanitize("${old_class_prefix}");
       "report"   usebundle => _log_v3("Replace lines with replacement into ${file}", "${file}", "${old_class_prefix}", "${class_prefix}", @{args});


### PR DESCRIPTION
https://issues.rudder.io/issues/14286