### PR TITLE
Fixes #16272: dbus service is not available on old os for the ncf tests

### DIFF
--- a/tests/acceptance/30_generic_methods/unsafe/service_reload.cf
+++ b/tests/acceptance/30_generic_methods/unsafe/service_reload.cf
@@ -27,8 +27,10 @@ bundle agent init
       "service_script" string => "crond";
     aix::
       "service_script" string => "syslogd";
-    debian|suse::
+    systemd.(debian|suse)::
       "service_script" string => "dbus";
+    !systemd.(debian|suse)::
+      "service_script" string => "cron";
 
     "c_service_script" string => canonify("${service_script}");
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/16272