### PR TITLE
Fixes #16274: Missing guarding class for service_reload tests

### DIFF
--- a/tests/acceptance/30_generic_methods/unsafe/service_reload.cf
+++ b/tests/acceptance/30_generic_methods/unsafe/service_reload.cf
@@ -32,7 +32,8 @@ bundle agent init
     !systemd.(debian|suse)::
       "service_script" string => "cron";
 
-    "c_service_script" string => canonify("${service_script}");
+    any::
+      "c_service_script" string => canonify("${service_script}");
 }
 
 #######################################################


### PR DESCRIPTION
https://issues.rudder.io/issues/16274