### PR TITLE
Fixes #16701: ncf api fails on Centos 7.6.1810

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,3 @@
 jinja2==2.10
-flask==0.12.4
+flask==0.12.5
 requests==2.19.1


### PR DESCRIPTION
https://issues.rudder.io/issues/16701