### PR TITLE
Fixes #17706: Add left margin to DSC icon in generic method name

### DIFF
--- a/builder/css/custom.css
+++ b/builder/css/custom.css
@@ -1056,6 +1056,9 @@ ul.list-unstyled > li{
   font-size: 16px;
   color: #222D42;
 }
+.method .method-name .dsc-icon {
+  margin-left: 6px;
+}
 .col-methods .method .method-name {
   cursor: pointer;
   padding: 8px;


### PR DESCRIPTION
https://issues.rudder.io/issues/17706