### PR TITLE
Fixes #18416: jinja templating script uses python3 even if jinja2 is not installed in python3 but is in python2

### DIFF
--- a/tree/10_ncf_internals/modules/templates/jinja2-templating.py
+++ b/tree/10_ncf_internals/modules/templates/jinja2-templating.py
@@ -2,9 +2,9 @@
 # vim: syntax=python
 ''':'
 # First try to run this script with python3, else run with python
-if command -v python3 >/dev/null 2>/dev/null; then
+if command -v python3 >/dev/null 2>/dev/null && python3 -c "import jinja2" >/dev/null 2>/dev/null; then
   exec python3 "$0" "$@"
-elif command -v python >/dev/null 2>/dev/null; then
+elif command -v python >/dev/null 2>/dev/null && python2 -c "import jinja2" >/dev/null 2>/dev/null; then
   exec python  "$0" "$@"
 else
   exec python2 "$0" "$@"


### PR DESCRIPTION
https://issues.rudder.io/issues/18416