### PR TITLE
Fixes #18446: Permissions recursive method uses an undefined "recursion" variable in its report string

### DIFF
--- a/tree/30_generic_methods/permissions_recursive.cf
+++ b/tree/30_generic_methods/permissions_recursive.cf
@@ -57,5 +57,5 @@ bundle agent permissions_recursive(path, mode, owner, group)
                             ifvarclass => "should_report";
       "new result classes"   usebundle => _classes_copy("${inner_class_prefix}", "${class_prefix}");
 
-      "report"               usebundle => _log_v3("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path} with ${recursion} recursion level", "${path}", "${old_class_prefix}", "${class_prefix}", @{args});
+      "report"               usebundle => _log_v3("Ensure permissions mode ${mode}, owner ${owner} and group ${group} on ${path} with inf recursion level", "${path}", "${old_class_prefix}", "${class_prefix}", @{args});
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/18446