### PR TITLE
Fixes #18505: when sum of length of parameter is larger than 1000 characters, reporting leaks too much from one method to another

### DIFF
--- a/tree/20_cfe_basics/log_rudder.cf
+++ b/tree/20_cfe_basics/log_rudder.cf
@@ -114,7 +114,7 @@ bundle agent log_rudder(message, class_parameter, old_class_prefix, class_prefix
       "class_prefix_unexpanded" expression => strcmp("", "${c_class_prefix}");
       "class_prefix_defined" expression => "!class_prefix_null.!class_prefix_empty.!class_prefix_unexpanded";
 
-      "class_prefix_size_ok" expression => isgreaterthan("1000", "${class_prefix_length}");
+      "class_prefix_size_ok" expression => isgreaterthan("1001", "${class_prefix_length}");
       "use_class_prefix"     expression => "class_prefix_defined.class_prefix_size_ok";
 
   methods:


### PR DESCRIPTION
https://issues.rudder.io/issues/18505