### PR TITLE
Fixes #18704: ncf uses its own cfengine port instead of rudder defined one

### DIFF
--- a/tree/10_ncf_internals/configuration.cf
+++ b/tree/10_ncf_internals/configuration.cf
@@ -30,7 +30,6 @@ bundle common configuration
       "trace" string => "[TRACE]";
 
       "enabled_abort_handlers" slist => { "_abort_default", "abort_rudder" };
-      "cfengine_port"         string => "5309";
       "flag_file"             string => "/var/rudder/agent-data/flags.json";
 
   classes:

--- a/tree/20_cfe_basics/files.cf
+++ b/tree/20_cfe_basics/files.cf
@@ -538,7 +538,7 @@ body copy_from ncf_remote_cp_method(from, server, method)
     servers     => { "${server}" };
     source      => "${from}";
     type_check  => "true";
-    portnumber  => "${configuration.cfengine_port}";
+    portnumber  => "${system_common.community_port}";
     compare     => "${method}";
     encrypt     => "true";
     copy_backup => "timestamp";


### PR DESCRIPTION
https://issues.rudder.io/issues/18704