### PR TITLE
Fixes #19390: Force pylint3 instead of pylint in qa-test

### DIFF
--- a/qa-test
+++ b/qa-test
@@ -13,7 +13,8 @@ test_unit()
 
 test_python()
 {
-  find . -path ./api -prune -o -name '*.py' -exec echo "Running pylint on {}" \; -exec pylint -E --disable=C,R --init-hook="import sys; sys.path.append('./tools')" --persistent=n {} \;
+  [ -x "$(command -v pylint3)" ] && pylintCmd="pylint3" || pylintCmd="pylint"
+  find . -path ./api -prune -o -name '*.py' -exec echo "Running pylint on {}" \; -exec ${pylintCmd} -E --disable=C,R --init-hook="import sys; sys.path.append('./tools')" --persistent=n {} \;
 }
 
 


### PR DESCRIPTION
https://issues.rudder.io/issues/19390