### PR TITLE
Fixes #20056: Remove ubuntu20 from the Jenkinsfile test since thehost is unstable atm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,8 +63,7 @@ pipeline {
                         "centos8",
                         "sles12",
                         "sles15",
-                        "ubuntu18_04",
-                        "ubuntu20_04"
+                        "ubuntu18_04"
                     ]
                     String ncf_path = "${workspace}/ncf"
                     testNcfLocal(agent_versions, systems, ncf_path)


### PR DESCRIPTION
https://issues.rudder.io/issues/20056