### PR TITLE
Fixes #19033: package method leads to report error when package with non-zero epoch is updated

### DIFF
--- a/tree/10_ncf_internals/modules/packages/yum
+++ b/tree/10_ncf_internals/modules/packages/yum
@@ -19,7 +19,7 @@ import re
 
 rpm_cmd = os.environ.get('CFENGINE_TEST_RPM_CMD', "/bin/rpm")
 rpm_quiet_option = ["--quiet"]
-rpm_output_format = "Name=%{name}\nVersion=%{version}-%{release}\nArchitecture=%{arch}\n"
+rpm_output_format = "Name=%{name}\nVersion=%|EPOCH?{%{epoch}:}:{}|%{version}-%{release}\nArchitecture=%{arch}\n"
 
 yum_cmd = os.environ.get('CFENGINE_TEST_YUM_CMD', "/usr/bin/yum")
 yum_options = ["--quiet", "-y"]


### PR DESCRIPTION
https://issues.rudder.io/issues/19033

Replacing previous PR: https://github.com/Normation/ncf/pull/1362
