### PR TITLE
Fixes #23652: iteration in technique editor with package method don't report correctly

### DIFF
--- a/tests/acceptance/default_ncf.cf.sub
+++ b/tests/acceptance/default_ncf.cf.sub
@@ -204,6 +204,7 @@ bundle agent apply_gm_v4(name, args, status, result_class, mode)
       "d_uuid"       string => canonify("d_${uuid}");
       "r_uuid"       string => canonify("r_${uuid}");
 
+      "c_arg0"       string => canonify("${arg0}");
   classes:
       "pass3" expression => "pass2";
       "pass2" expression => "pass1";
@@ -239,7 +240,7 @@ bundle agent apply_gm_v4(name, args, status, result_class, mode)
     pass2::
       "expected_classes" usebundle => define_expected_classes("${class_prefix}", "${status}", "class_prefix_${result_class}"),
               comment => "${c_uuid}";
-      "expected_classes" usebundle => define_expected_classes("${c_uuid}_${d_uuid}", "${status}", "method_id_${result_class}"),
+      "expected_classes" usebundle => define_expected_classes("${c_uuid}_${d_uuid}_${c_arg0}", "${status}", "method_id_${result_class}"),
               comment => "${c_uuid}";
 
 
@@ -292,6 +293,8 @@ bundle agent apply_gm_v4(name, args, status, result_class, mode)
       "Found unexpected class ${define_expected_classes.unexpected_classes_class_prefix_${result_class}}"
         ifvarclass => "${define_expected_classes.unexpected_classes_class_prefix_${result_class}}",
                 comment => "${c_uuid}";
+                
+   "Arg0 canonified is ${c_arg0}";
 }
 
 # Mimic default node properties values

--- a/tests/acceptance/testall
+++ b/tests/acceptance/testall
@@ -24,7 +24,6 @@
 #
 
 set -e
-
 #
 # Detect and replace non-POSIX shell
 #

--- a/tree/20_cfe_basics/log_rudder.cf
+++ b/tree/20_cfe_basics/log_rudder.cf
@@ -517,9 +517,9 @@ bundle agent _method_reporting_context_v4(c_name, c_key, report_id)
     # Non-canonified version, to be used in reports
     "report_data.report_id_r"    string => "${report_id}";
     # Canonified version, to be used in policies (as class prefix)
-    # it needs the directive_id to enforce unicity
-    "report_data.report_id"      string => canonify("${report_id}_${c_key}_${report_data.directive_id}");
-    "report_data.method_id"      string => canonify("${report_id}_${c_key}_${report_data.directive_id}");
+    # it needs the directive_id to enforce unicity, and the c_key to work with iterator
+    "report_data.report_id"      string => canonify("${report_id}_${report_data.directive_id}_${c_key}");
+    "report_data.method_id"      string => canonify("${report_id}_${report_data.directive_id}_${c_key}");
     "report_data.identifier"     string => "${report_data.rule_id}@@${report_data.directive_id}@@${report_data.report_id_r}";
 
   methods:

--- a/tree/20_cfe_basics/log_rudder.cf
+++ b/tree/20_cfe_basics/log_rudder.cf
@@ -518,8 +518,8 @@ bundle agent _method_reporting_context_v4(c_name, c_key, report_id)
     "report_data.report_id_r"    string => "${report_id}";
     # Canonified version, to be used in policies (as class prefix)
     # it needs the directive_id to enforce unicity
-    "report_data.report_id"      string => canonify("${report_id}_${report_data.directive_id}");
-    "report_data.method_id"      string => canonify("${report_id}_${report_data.directive_id}");
+    "report_data.report_id"      string => canonify("${report_id}_${c_key}_${report_data.directive_id}");
+    "report_data.method_id"      string => canonify("${report_id}_${c_key}_${report_data.directive_id}");
     "report_data.identifier"     string => "${report_data.rule_id}@@${report_data.directive_id}@@${report_data.report_id_r}";
 
   methods:

--- a/tree/30_generic_methods/command_execution.cf
+++ b/tree/30_generic_methods/command_execution.cf
@@ -74,7 +74,7 @@ bundle agent command_execution(command)
 
   methods:
     pass3.dry_run::
-      "${report_data.method_id}" usebundle  => _classes_noop("${report_data.method_id}");
+      "${report_data.method_id}" usebundle  => _classes_noop("${report_data.method_id}_${command}");
       "${report_data.method_id}" usebundle  => _classes_noop("${class_prefix}");
     pass3::
       "${report_data.method_id}" usebundle  => log_rudder_v4("${command}", "Execute command", "${command}");
@@ -82,5 +82,5 @@ bundle agent command_execution(command)
     pass2.!pass3.!dry_run::
       "${command}"
         contain      => in_shell,
-        classes      => classes_generic_two("${report_data.method_id}", "${class_prefix}");
+        classes      => classes_generic_two("${report_data.method_id}_${command}", "${class_prefix}");
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/23652

This change adds a variability based on the key for generic methods.
To allow multiple execution of generic method based on service command and package, we introduced a stack for evaluation & reporting, that uses generic method id + directive + rule as an id
This solves the issue of multiple evaluations, yet it does not work with reporting: a list of package to install, with the first in repair and the other in success return repair for all the package, breaking the reporting

We have a facility to unwrap the list in the generated technique

` 27 bundle agent iteration_gm_1(c_name, c_key, report_id, name, version, architecture, provider) {
 28   methods:
 29     "c3974f2e-d9e9-4527-ab5f-e0add1c52318_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
 30     "c3974f2e-d9e9-4527-ab5f-e0add1c52318_${report_data.directive_id}" usebundle => package_present("${name}","${version}","${architecture}","${provider}");
 31 }`

which was introduced in https://issues.rudder.io/issues/20603

so, we could be insensitive to iteration if we add the key to the report
For packages, command and services, report_id and method_id are both used for defining classes & report condition (and I suspect that one in use in place of the other more than once); so adding in them the key allow unicity
This is was this change does and fixes the reporting issue

It needs to be more throughly tested, especially for the result condution of the GM, and for techniques, and services & command