### PR TITLE
Fixes #24806: Fix remaining warnings in apt_get module with python 3.12

### DIFF
--- a/tree/10_ncf_internals/modules/packages/apt_get
+++ b/tree/10_ncf_internals/modules/packages/apt_get
@@ -212,7 +212,7 @@ def list_updates(online):
         #                repository(ies)      arch (might be optional)
         #                       |               |
         #                    /--+-\   /---------+---------\
-                         "(?:\s+\S+)*?(\s+\[(?P<arch>[^]\s]+)\])?\).*", line)
+                         r"(?:\s+\S+)*?(\s+\[(?P<arch>[^]\s]+)\])?\).*", line)
 
         if match is not None:
             sys.stdout.write("Name=" + match.group("name") + "\n")


### PR DESCRIPTION
https://issues.rudder.io/issues/24806